### PR TITLE
feat: added in postgres deployment and unit tests

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -50,3 +50,36 @@ Selector labels
 app.kubernetes.io/name: {{ include "control-layer.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Common labels for postgres
+*/}}
+{{- define "control-layer.postgres.labels" -}}
+helm.sh/chart: {{ include "control-layer.chart" . }}
+{{ include "control-layer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: postgres
+{{- end }}
+
+{{/*
+Selector labels for postgres
+*/}}
+{{- define "control-layer.postgres.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "control-layer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: postgres
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "control-layer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "control-layer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,6 +9,7 @@ spec:
   selector:
     matchLabels:
       {{- include "control-layer.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: control-layer
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -25,9 +26,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccountName }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+      serviceAccountName: {{ include "control-layer.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/templates/postgres/secret.yaml
+++ b/templates/postgres/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.secrets.postgres.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "control-layer.fullname" . }}-postgres-secret
+  labels:
+    {{- include "control-layer.postgres.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with .Values.secrets.postgres.data }}
+  {{- range $key, $value := . }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/templates/postgres/service.yaml
+++ b/templates/postgres/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "control-layer.fullname" . }}-postgres
+  labels:
+    {{- include "control-layer.postgres.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    {{- include "control-layer.postgres.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/templates/postgres/statefulset.yaml
+++ b/templates/postgres/statefulset.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "control-layer.fullname" . }}-postgres
+  labels:
+    {{- include "control-layer.postgres.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "control-layer.fullname" . }}-postgres
+  replicas: {{ .Values.postgresql.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "control-layer.postgres.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.postgresql.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "control-layer.postgres.labels" . | nindent 8 }}
+        {{- with .Values.postgresql.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "control-layer.serviceAccountName" . }}
+      {{- with .Values.postgresql.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgres
+          {{- with .Values.postgresql.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            {{- $secretName := .Values.secrets.postgres.name | default (printf "%s-postgres-secret" (include "control-layer.fullname" $)) }}
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U $POSTGRES_USER -d $POSTGRES_DB
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U $POSTGRES_USER -d $POSTGRES_DB
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 6
+          {{- with .Values.postgresql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+        {{- with .Values.postgresql.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- range .Values.postgresql.persistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- if .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ .Values.postgresql.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size | quote }}
+  {{- else }}
+      volumes:
+        - name: postgres-data
+          emptyDir: {}
+  {{- end }}
+{{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -13,3 +13,4 @@ spec:
       name: http
   selector:
     {{- include "control-layer.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: control-layer

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "control-layer.serviceAccountName" . }}
+  labels:
+    {{- include "control-layer.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/tests/configmap_test.yaml
+++ b/tests/configmap_test.yaml
@@ -1,0 +1,175 @@
+suite: test configmap generation and mounting
+templates:
+  - configmap.yaml
+  - deployment.yaml
+tests:
+  # ConfigMap Creation Tests
+  - it: should create control-layer configmap with default configuration
+    template: configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-config
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: control-layer
+      - isNotNull:
+          path: data["control-layer-config.yaml"]
+
+  - it: should include default control-layer configuration in configmap
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'host: "0\.0\.0\.0"'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'port: 3001'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'secret_key: "your-secret-key-here"'
+
+  - it: should use custom control-layer configuration when provided
+    set:
+      config: |
+        # Custom Control Layer Configuration
+        host: "127.0.0.1"
+        port: 8080
+        admin_email: "admin@example.com"
+        
+        model_sources:
+          - name: "Production"
+            url: "http://prod-server:9000"
+            sync_interval: "30s"
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'host: "127\.0\.0\.1"'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'port: 8080'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'admin_email: "admin@example\.com"'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'name: "Production"'
+
+  # ConfigMap Mounting Tests
+  - it: should mount configmap in control-layer deployment
+    templates:
+      - deployment.yaml
+      - configmap.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /app/config.yaml
+            subPath: control-layer-config.yaml
+            readOnly: true
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-control-layer-config
+        template: deployment.yaml
+
+  - it: should have consistent configmap name between configmap and deployment
+    templates:
+      - deployment.yaml
+      - configmap.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-config
+        template: configmap.yaml
+      - equal:
+          path: spec.template.spec.volumes[0].configMap.name
+          value: RELEASE-NAME-control-layer-config
+        template: deployment.yaml
+
+  - it: should have correct labels on configmap
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: metadata.labels["helm.sh/chart"]
+          pattern: ^control-layer-[0-9]+\.[0-9]+\.[0-9]+$
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: control-layer
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: control-layer
+
+  - it: should handle multi-line YAML configuration correctly
+    set:
+      config: |
+        # Control Layer Configuration with complex structure
+        host: "0.0.0.0"
+        port: 3001
+        
+        model_sources:
+          - name: "GPT-4"
+            url: "https://api.openai.com/v1"
+            sync_interval: "15s"
+            headers:
+              Authorization: "Bearer token"
+          - name: "Claude"
+            url: "https://api.anthropic.com/v1"
+            sync_interval: "20s"
+        
+        metadata:
+          region: "us-west-2"
+          environment: "production"
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'name: "GPT-4"'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'name: "Claude"'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'Authorization: "Bearer token"'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'environment: "production"'
+
+  - it: should preserve YAML formatting and indentation
+    set:
+      config: |
+        host: "0.0.0.0"
+        nested:
+          level1:
+            level2:
+              value: "deep"
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'host: "0\.0\.0\.0"'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: 'nested:'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: '  level1:'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: '    level2:'
+      - matchRegex:
+          path: data["control-layer-config.yaml"]
+          pattern: '      value: "deep"'

--- a/tests/control_layer_deployment_test.yaml
+++ b/tests/control_layer_deployment_test.yaml
@@ -1,0 +1,68 @@
+suite: test control-layer deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: should create control-layer deployment with default appVersion
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: -control-layer$
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/doublewordai/control-layer:.*$
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: control-layer
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should use custom image tag when specified
+    set:
+      image.tag: "custom-tag"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/doublewordai/control-layer:custom-tag
+
+  - it: should mount config and use secrets when enabled
+    set:
+      secrets.controlLayer.create: true
+      secrets.controlLayer.data.DATABASE_URL: "postgres://test"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /app/config.yaml
+            subPath: control-layer-config.yaml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-control-layer-config
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-control-layer-secret
+                key: DATABASE_URL
+
+  - it: should use correct labels and selectors
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: control-layer
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: control-layer
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: control-layer
+

--- a/tests/postgresql_test.yaml
+++ b/tests/postgresql_test.yaml
@@ -1,0 +1,210 @@
+suite: test postgresql statefulset configuration
+templates:
+  - postgres/statefulset.yaml
+tests:
+  - it: should not create statefulset when postgresql is disabled
+    set:
+      postgresql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create statefulset with default configuration
+    set:
+      postgresql.enabled: true
+      secrets.postgres.create: true
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-postgres
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: postgres
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-control-layer-postgres
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "postgres:15"
+
+  - it: should use custom image configuration when specified
+    set:
+      postgresql.enabled: true
+      postgresql.image.repository: "custom-postgres"
+      postgresql.image.tag: "14"
+      postgresql.image.pullPolicy: "Always"
+      secrets.postgres.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "custom-postgres:14"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"
+
+  - it: should configure environment variables from secrets
+    set:
+      postgresql.enabled: true
+      secrets.postgres.create: true
+      secrets.postgres.name: "custom-postgres-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_DB
+            valueFrom:
+              secretKeyRef:
+                name: custom-postgres-secret
+                key: POSTGRES_DB
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                name: custom-postgres-secret
+                key: POSTGRES_USER
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: custom-postgres-secret
+                key: POSTGRES_PASSWORD
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGDATA
+            value: "/var/lib/postgresql/data/pgdata"
+
+  - it: should configure volume mounts
+    set:
+      postgresql.enabled: true
+      secrets.postgres.create: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: postgres-data
+            mountPath: /var/lib/postgresql/data
+
+  - it: should configure probes correctly
+    set:
+      postgresql.enabled: true
+      secrets.postgres.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value:
+            - sh
+            - -c
+            - pg_isready -U $POSTGRES_USER -d $POSTGRES_DB
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value:
+            - sh
+            - -c
+            - pg_isready -U $POSTGRES_USER -d $POSTGRES_DB
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 5
+
+  - it: should create persistent volume claim template when persistence enabled
+    set:
+      postgresql.enabled: true
+      postgresql.persistence.enabled: true
+      postgresql.persistence.size: "10Gi"
+      postgresql.persistence.storageClass: "fast-ssd"
+      postgresql.persistence.accessModes:
+        - ReadWriteOnce
+      secrets.postgres.create: true
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: postgres-data
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: "10Gi"
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: "fast-ssd"
+      - contains:
+          path: spec.volumeClaimTemplates[0].spec.accessModes
+          content: "ReadWriteOnce"
+
+  - it: should use emptyDir when persistence is disabled
+    set:
+      postgresql.enabled: true
+      postgresql.persistence.enabled: false
+      secrets.postgres.create: true
+    asserts:
+      - isNull:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: postgres-data
+            emptyDir: {}
+
+  - it: should configure security contexts
+    set:
+      postgresql.enabled: true
+      postgresql.podSecurityContext.fsGroup: 999
+      postgresql.securityContext.runAsUser: 999
+      postgresql.securityContext.runAsGroup: 999
+      postgresql.securityContext.runAsNonRoot: true
+      secrets.postgres.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should configure resources when specified
+    set:
+      postgresql.enabled: true
+      postgresql.resources.limits.cpu: "500m"
+      postgresql.resources.limits.memory: "512Mi"
+      postgresql.resources.requests.cpu: "250m"
+      postgresql.resources.requests.memory: "256Mi"
+      secrets.postgres.create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "500m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "512Mi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "250m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "256Mi"
+
+  - it: should configure replica count
+    set:
+      postgresql.enabled: true
+      postgresql.replicaCount: 3
+      secrets.postgres.create: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3

--- a/tests/secrets_test.yaml
+++ b/tests/secrets_test.yaml
@@ -1,0 +1,129 @@
+suite: test secrets configuration
+templates:
+  - secret.yaml
+  - postgres/secret.yaml
+tests:
+  # Control Layer Secret Tests
+  - it: should not create control-layer secret when create is false
+    set:
+      secrets.controlLayer.create: false
+    template: secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create control-layer secret with explicit DATABASE_URL
+    set:
+      secrets.controlLayer.create: true
+      secrets.controlLayer.data.DATABASE_URL: "postgres://external:pass@host:5432/db"
+      secrets.controlLayer.data.API_KEY: "test-key"
+    template: secret.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-secret
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: control-layer
+      - equal:
+          path: stringData.DATABASE_URL
+          value: "postgres://external:pass@host:5432/db"
+      - equal:
+          path: stringData.API_KEY
+          value: "test-key"
+
+  - it: should auto-generate DATABASE_URL when empty and postgresql enabled
+    set:
+      secrets.controlLayer.create: true
+      secrets.controlLayer.data.DATABASE_URL: ""
+      secrets.controlLayer.data.API_KEY: "test-key"
+      postgresql.enabled: true
+      secrets.postgres.data.POSTGRES_USER: "testuser"
+      secrets.postgres.data.POSTGRES_PASSWORD: "testpass"
+      secrets.postgres.data.POSTGRES_DB: "testdb"
+    template: secret.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.DATABASE_URL
+          value: "postgres://testuser:testpass@RELEASE-NAME-postgres:5432/testdb"
+      - equal:
+          path: stringData.API_KEY
+          value: "test-key"
+
+  - it: should not include empty values in control-layer secret
+    set:
+      secrets.controlLayer.create: true
+      secrets.controlLayer.data.DATABASE_URL: "postgres://test"
+      secrets.controlLayer.data.EMPTY_VALUE: ""
+      secrets.controlLayer.data.API_KEY: "valid-key"
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: stringData.DATABASE_URL
+          value: "postgres://test"
+      - equal:
+          path: stringData.API_KEY
+          value: "valid-key"
+      - isNull:
+          path: stringData.EMPTY_VALUE
+
+  # PostgreSQL Secret Tests
+  - it: should not create postgres secret when create is false
+    set:
+      secrets.postgres.create: false
+    template: postgres/secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create postgres secret with credentials
+    set:
+      secrets.postgres.create: true
+      secrets.postgres.data.POSTGRES_USER: "dbuser"
+      secrets.postgres.data.POSTGRES_PASSWORD: "dbpass"
+      secrets.postgres.data.POSTGRES_DB: "mydb"
+    template: postgres/secret.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-postgres-secret
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: postgres
+      - equal:
+          path: stringData.POSTGRES_USER
+          value: "dbuser"
+      - equal:
+          path: stringData.POSTGRES_PASSWORD
+          value: "dbpass"
+      - equal:
+          path: stringData.POSTGRES_DB
+          value: "mydb"
+
+  # Cross-template integration test
+  - it: should work with custom secret names
+    set:
+      secrets.controlLayer.create: true
+      secrets.controlLayer.name: "custom-control-layer-secret"
+      secrets.postgres.create: true
+      secrets.postgres.name: "custom-postgres-secret"
+      secrets.controlLayer.data.DATABASE_URL: "postgres://test"
+      secrets.postgres.data.POSTGRES_USER: "user"
+    templates:
+      - secret.yaml
+      - postgres/secret.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-secret
+        template: secret.yaml
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-postgres-secret
+        template: postgres/secret.yaml

--- a/tests/serviceaccount_test.yaml
+++ b/tests/serviceaccount_test.yaml
@@ -1,0 +1,80 @@
+suite: test service account configuration
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should not create service account when create is false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create service account with default values
+    set:
+      serviceAccount.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+      - isNotNull:
+          path: metadata.labels
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: control-layer
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should use custom service account name
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: "custom-sa"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+
+  - it: should add custom annotations
+    set:
+      serviceAccount.create: true
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/my-role"
+        example.com/annotation: "test-value"
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::123456789012:role/my-role"
+      - equal:
+          path: metadata.annotations["example.com/annotation"]
+          value: "test-value"
+
+  - it: should disable automount when set to false
+    set:
+      serviceAccount.create: true
+      serviceAccount.automount: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should enable automount when set to true
+    set:
+      serviceAccount.create: true
+      serviceAccount.automount: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: should not have annotations section when empty
+    set:
+      serviceAccount.create: true
+      serviceAccount.annotations: {}
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/tests/services_test.yaml
+++ b/tests/services_test.yaml
@@ -1,0 +1,128 @@
+suite: test service configurations and port mappings
+templates:
+  - service.yaml
+  - postgres/service.yaml
+tests:
+  # Control Layer Service Tests
+  - it: should create control-layer service with default configuration
+    template: service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: control-layer
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 3001
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+      - equal:
+          path: spec.ports[0].name
+          value: http
+
+  - it: should configure control-layer service with custom values
+    set:
+      service.type: "LoadBalancer"
+      service.port: 8080
+    template: service.yaml
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+
+  - it: should have correct control-layer service selector
+    template: service.yaml
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: control-layer
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: control-layer
+
+  # PostgreSQL Service Tests
+  - it: should not create postgres service when postgresql is disabled
+    set:
+      postgresql.enabled: false
+    template: postgres/service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create postgres service when postgresql is enabled
+    set:
+      postgresql.enabled: true
+    template: postgres/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-postgres
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: postgres
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 5432
+      - equal:
+          path: spec.ports[0].targetPort
+          value: postgres
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+      - equal:
+          path: spec.ports[0].name
+          value: postgres
+
+  - it: should have correct postgres service selector
+    set:
+      postgresql.enabled: true
+    template: postgres/service.yaml
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: control-layer
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: postgres
+
+  # Cross-service integration test
+  - it: should create all services with proper component labels
+    set:
+      postgresql.enabled: true
+    templates:
+      - service.yaml
+      - postgres/service.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: control-layer
+        template: service.yaml
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: postgres
+        template: postgres/service.yaml

--- a/values.yaml
+++ b/values.yaml
@@ -9,8 +9,17 @@ fullnameOverride: ""
 # This is for the secrets for pulling an image from a private repository
 imagePullSecrets: []
 
-# Service account reference (expected to be created by parent chart)
-serviceAccountName: ""
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
 
 # Service-specific secrets configuration
 secrets:
@@ -25,14 +34,12 @@ secrets:
 
   # PostgreSQL database credentials (used if postgresql.enabled is true)
   postgres:
+    create: true
+    name: ""
     data:
       POSTGRES_DB: "clay"
       POSTGRES_USER: "clay"
       POSTGRES_PASSWORD: "clay_password"
-
-# PostgreSQL configuration (for determining internal vs external DB)
-postgresql:
-  enabled: true
 
 # This will set the replicaset count
 replicaCount: 1
@@ -147,3 +154,44 @@ config: |
 
   # Secret key for session signing (set via DWCTL_SECRET_KEY environment variable)
   secret_key: "your-secret-key-here"
+
+# PostgreSQL Database Configuration
+# Set enabled: true to deploy PostgreSQL as part of this chart
+# Set enabled: false to use external PostgreSQL (configure DATABASE_URL via secrets.controlLayer.data)
+postgresql:
+  # Deploy internal PostgreSQL StatefulSet
+  enabled: true
+
+  # StatefulSet configuration (only used when enabled: true)
+  replicaCount: 1
+
+  image:
+    repository: postgres
+    pullPolicy: IfNotPresent
+    tag: "15"
+
+  # Database credentials are read from secrets.postgres
+
+  # Data persistence settings (only used when enabled: true)
+  persistence:
+    # Set to false for ephemeral storage (data lost on pod restart)
+    enabled: true
+    # Leave empty to use cluster default storage class
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+    annotations: {}
+
+  # Pod Security Configuration
+  # These settings ensure PostgreSQL runs as the postgres user (UID/GID 999)
+  # and that mounted volumes have correct ownership
+  podSecurityContext:
+    # Sets group ownership of mounted volumes to postgres group
+    fsGroup: 999
+  securityContext:
+    # Run container as postgres user (standard for postgres Docker image)
+    runAsUser: 999
+    runAsGroup: 999
+    # Security best practice - prevent running as root
+    runAsNonRoot: true


### PR DESCRIPTION
Adding in postgres statefulset to make standalone deployments easier for the control layer. Can be switched off if integrating into an existing DB. Added unit testing around helm chart as well.