### PR TITLE
fix: add emails to fusillade in case it wins the leadership election

### DIFF
--- a/templates/fusillade/deployment.yaml
+++ b/templates/fusillade/deployment.yaml
@@ -106,6 +106,11 @@ spec:
               mountPath: /app/config.yaml
               subPath: control-layer-config.yaml
               readOnly: true
+            {{- if .Values.emailTemplates.enabled }}
+            - name: email-templates
+              mountPath: {{ .Values.emailTemplates.mountPath }}
+              readOnly: true
+            {{- end }}
             {{- with .Values.fusillade.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -116,6 +121,11 @@ spec:
         - name: config
           configMap:
             name: {{ include "control-layer.fullname" . }}-config
+        {{- if .Values.emailTemplates.enabled }}
+        - name: email-templates
+          configMap:
+            name: {{ include "control-layer.fullname" . }}-email-templates
+        {{- end }}
         {{- with .Values.fusillade.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds email templates volume mount support to the fusillade deployment, ensuring that when fusillade wins the leadership election and handles batch processing, it has access to the same email templates as the main control-layer deployment.

- Mirrors the exact pattern from `templates/deployment.yaml` (added in PR #64)
- Conditionally mounts the `email-templates` ConfigMap when `emailTemplates.enabled` is true
- Ensures consistency between control-layer and fusillade deployments for email functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change mirrors an established pattern from the main deployment (PR #64), uses conditional mounting with proper guards, follows Helm best practices, and maintains consistency across deployments
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| templates/fusillade/deployment.yaml | Added email-templates volume mount and volume definition to fusillade deployment, mirroring the pattern from main deployment |

</details>



<sub>Last reviewed commit: fcdcb60</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->