### PR TITLE
fix(chart): roll pods when mounted Secret/ConfigMap changes

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -12,10 +12,12 @@ spec:
       app.kubernetes.io/component: control-layer
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "control-layer.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/templates/fusillade/deployment.yaml
+++ b/templates/fusillade/deployment.yaml
@@ -12,10 +12,12 @@ spec:
       {{- include "control-layer.fusillade.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.fusillade.podAnnotations }}
       annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.fusillade.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "control-layer.fusillade.labels" . | nindent 8 }}
         {{- with .Values.fusillade.podLabels }}

--- a/templates/postgres/statefulset.yaml
+++ b/templates/postgres/statefulset.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "control-layer.postgres.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.postgresql.podAnnotations }}
       annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/postgres/secret.yaml") . | sha256sum }}
+        {{- with .Values.postgresql.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "control-layer.postgres.labels" . | nindent 8 }}
         {{- with .Values.postgresql.podLabels }}

--- a/tests/configmap_test.yaml
+++ b/tests/configmap_test.yaml
@@ -2,6 +2,7 @@ suite: test configmap generation and mounting
 templates:
   - configmap.yaml
   - deployment.yaml
+  - secret.yaml
 tests:
   # ConfigMap Creation Tests
   - it: should create control-layer configmap with default configuration

--- a/tests/control_layer_deployment_test.yaml
+++ b/tests/control_layer_deployment_test.yaml
@@ -1,8 +1,11 @@
 suite: test control-layer deployment
 templates:
   - deployment.yaml
+  - configmap.yaml
+  - secret.yaml
 tests:
   - it: should create control-layer deployment with default appVersion
+    template: deployment.yaml
     asserts:
       - isKind:
           of: Deployment
@@ -20,6 +23,7 @@ tests:
           value: 1
 
   - it: should use custom image tag when specified
+    template: deployment.yaml
     set:
       image.tag: "custom-tag"
     asserts:
@@ -28,6 +32,7 @@ tests:
           value: ghcr.io/doublewordai/control-layer:custom-tag
 
   - it: should mount config and use secrets when enabled
+    template: deployment.yaml
     set:
       secrets.controlLayer.data.DATABASE_URL: "postgres://test"
     asserts:
@@ -51,6 +56,7 @@ tests:
               name: RELEASE-NAME-control-layer-secret
 
   - it: should use correct labels and selectors
+    template: deployment.yaml
     asserts:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]

--- a/tests/fusillade_deployment_test.yaml
+++ b/tests/fusillade_deployment_test.yaml
@@ -1,8 +1,11 @@
 suite: test fusillade deployment
 templates:
   - fusillade/deployment.yaml
+  - configmap.yaml
+  - secret.yaml
 tests:
   - it: should not create fusillade deployment when disabled
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: false
     asserts:
@@ -10,6 +13,7 @@ tests:
           count: 0
 
   - it: should create fusillade deployment when enabled
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
     asserts:
@@ -26,6 +30,7 @@ tests:
           value: fusillade
 
   - it: should always enable batch daemon via env var
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
     asserts:
@@ -36,6 +41,7 @@ tests:
             value: "always"
 
   - it: should set database pool env vars when fusillade.database.pool is configured
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
       fusillade.database.pool.max_connections: 100
@@ -53,6 +59,7 @@ tests:
             value: "5"
 
   - it: should set replica pool env vars when fusillade.database.replica_pool is configured
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
       fusillade.database.replica_pool.max_connections: 200
@@ -70,6 +77,7 @@ tests:
             value: "10"
 
   - it: should set fusillade schema pool env vars when configured
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
       fusillade.database.fusillade_pool.max_connections: 500
@@ -87,6 +95,7 @@ tests:
             value: "1"
 
   - it: should set fusillade replica pool env vars when configured
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
       fusillade.database.fusillade_replica_pool.max_connections: 300
@@ -98,6 +107,7 @@ tests:
             value: "300"
 
   - it: should set outlet pool env vars when configured
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
       fusillade.database.outlet_pool.max_connections: 150
@@ -115,6 +125,7 @@ tests:
             value: "150"
 
   - it: should set all pool settings together
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
       fusillade.database.pool.max_connections: 100
@@ -156,6 +167,7 @@ tests:
             value: "200"
 
   - it: should not set database pool env vars when not configured
+    template: fusillade/deployment.yaml
     set:
       fusillade.enabled: true
     asserts:

--- a/tests/postgresql_test.yaml
+++ b/tests/postgresql_test.yaml
@@ -1,8 +1,10 @@
 suite: test postgresql statefulset configuration
 templates:
   - postgres/statefulset.yaml
+  - postgres/secret.yaml
 tests:
   - it: should not create statefulset when postgresql is disabled
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: false
     asserts:
@@ -10,6 +12,7 @@ tests:
           count: 0
 
   - it: should create statefulset with default configuration
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       secrets.postgres.create: true
@@ -33,6 +36,7 @@ tests:
           value: "postgres:15"
 
   - it: should use custom image configuration when specified
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       postgresql.image.repository: "custom-postgres"
@@ -48,6 +52,7 @@ tests:
           value: "Always"
 
   - it: should configure environment variables from secrets
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       secrets.postgres.create: true
@@ -83,6 +88,7 @@ tests:
             value: "/var/lib/postgresql/data/pgdata"
 
   - it: should configure volume mounts
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       secrets.postgres.create: true
@@ -94,6 +100,7 @@ tests:
             mountPath: /var/lib/postgresql/data
 
   - it: should configure probes correctly
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       secrets.postgres.create: true
@@ -118,6 +125,7 @@ tests:
           value: 5
 
   - it: should create persistent volume claim template when persistence enabled
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       postgresql.persistence.enabled: true
@@ -141,6 +149,7 @@ tests:
           content: "ReadWriteOnce"
 
   - it: should use emptyDir when persistence is disabled
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       postgresql.persistence.enabled: false
@@ -155,6 +164,7 @@ tests:
             emptyDir: {}
 
   - it: should configure security contexts
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       postgresql.podSecurityContext.fsGroup: 999
@@ -177,6 +187,7 @@ tests:
           value: true
 
   - it: should configure resources when specified
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       postgresql.resources.limits.cpu: "500m"
@@ -199,6 +210,7 @@ tests:
           value: "256Mi"
 
   - it: should configure replica count
+    template: postgres/statefulset.yaml
     set:
       postgresql.enabled: true
       postgresql.replicaCount: 3


### PR DESCRIPTION
## Problem

When helm upgrade updates a Secret or ConfigMap mounted by a Deployment, Kubernetes doesn't roll the pod. Env vars from \`envFrom: secretRef\` and \`valueFrom.secretKeyRef\` are captured at pod start and never re-read. Result: values.yaml change lands, Secret updates, but the running pod keeps stale values.

Noticed this during the scouter curie migration (fixed in scouter#53) — worth mirroring here since the control-layer, fusillade, and postgres pods all mount Secrets / ConfigMaps this way.

## Fix

Standard Helm idiom: add a \`checksum/<target>\` pod annotation whose value is \`sha256sum\` of the rendered Secret / ConfigMap template. Content change → hash change → pod template change → rolling update. No change, same hash, no roll.

Annotations:

- **control-layer** \`Deployment\`: \`checksum/secret\`, \`checksum/config\`
- **fusillade** \`Deployment\`: \`checksum/secret\`, \`checksum/config\`
- **postgres** \`StatefulSet\`: \`checksum/secret\` (points at the subdirectory \`postgres/secret.yaml\`)

## Test plan

- [x] \`just lint\` passes
- [x] \`just test\` — 64 tests pass (adds \`template:\` scoping to test cases so they don't accidentally assert across sibling templates now loaded for \`include\` resolution)