### PR TITLE
feat: add ZDR keystore (Redis) and wrap-key wiring

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -105,3 +105,25 @@ app.kubernetes.io/name: {{ include "control-layer.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: fusillade
 {{- end }}
+
+{{/*
+Common labels for keystore (ZDR key custody Redis)
+*/}}
+{{- define "control-layer.keystore.labels" -}}
+helm.sh/chart: {{ include "control-layer.chart" . }}
+{{ include "control-layer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: keystore
+{{- end }}
+
+{{/*
+Selector labels for keystore
+*/}}
+{{- define "control-layer.keystore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "control-layer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: keystore
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -66,12 +66,16 @@ spec:
             # keystore Service; current_wrap_key_id comes from values. The wrap
             # key(s) themselves are the only piece the operator supplies as a
             # secret (secrets.controlLayer.data: DWCTL_KEYSTORE__WRAP_KEYS__<ID>).
-            # default_ttl_seconds defaults in dwctl; override it in the `config`
-            # blob if needed.
+            # default_ttl_seconds defaults in dwctl (7200s); set
+            # keystore.defaultTtlSeconds to override it.
             - name: DWCTL_KEYSTORE__REDIS_URL
               value: "redis://{{ include "control-layer.fullname" . }}-keystore:6379"
             - name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
               value: {{ .Values.keystore.currentWrapKeyId | quote }}
+            {{- with .Values.keystore.defaultTtlSeconds }}
+            - name: DWCTL_KEYSTORE__DEFAULT_TTL_SECONDS
+              value: {{ . | quote }}
+            {{- end }}
             {{- end }}
             {{- with .Values.env }}
             {{- range $key, $value := . }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -61,6 +61,18 @@ spec:
             - name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__ENABLED
               value: "never"
             {{- end }}
+            {{- if .Values.keystore.enabled }}
+            # ZDR keystore wiring. redis_url always points at the in-cluster
+            # keystore Service; current_wrap_key_id comes from values. The wrap
+            # key(s) themselves are the only piece the operator supplies as a
+            # secret (secrets.controlLayer.data: DWCTL_KEYSTORE__WRAP_KEYS__<ID>).
+            # default_ttl_seconds defaults in dwctl; override it in the `config`
+            # blob if needed.
+            - name: DWCTL_KEYSTORE__REDIS_URL
+              value: "redis://{{ include "control-layer.fullname" . }}-keystore:6379"
+            - name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
+              value: {{ .Values.keystore.currentWrapKeyId | quote }}
+            {{- end }}
             {{- with .Values.env }}
             {{- range $key, $value := . }}
             - name: {{ $key }}

--- a/templates/keystore/service.yaml
+++ b/templates/keystore/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.keystore.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "control-layer.fullname" . }}-keystore
+  labels:
+    {{- include "control-layer.keystore.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "control-layer.keystore.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/templates/keystore/statefulset.yaml
+++ b/templates/keystore/statefulset.yaml
@@ -15,10 +15,10 @@ spec:
       {{- include "control-layer.keystore.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.keystore.podAnnotations }}
       annotations:
-        {{- with .Values.keystore.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "control-layer.keystore.labels" . | nindent 8 }}
         {{- with .Values.keystore.podLabels }}

--- a/templates/keystore/statefulset.yaml
+++ b/templates/keystore/statefulset.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.keystore.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "control-layer.fullname" . }}-keystore
+  labels:
+    {{- include "control-layer.keystore.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "control-layer.fullname" . }}-keystore
+  # Single instance by design: the keystore is a strongly-consistent custody
+  # store for short-lived keys, not a cache. Do not scale this up.
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "control-layer.keystore.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.keystore.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "control-layer.keystore.labels" . | nindent 8 }}
+        {{- with .Values.keystore.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "control-layer.serviceAccountName" . }}
+      {{- with .Values.keystore.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: keystore
+          {{- with .Values.keystore.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.keystore.image.repository }}:{{ .Values.keystore.image.tag }}"
+          imagePullPolicy: {{ .Values.keystore.image.pullPolicy }}
+          # Append-only file on: keys (with their absolute TTLs) survive a
+          # restart or reschedule, so the crypto-shred clock is not reset. Data
+          # dir is the persisted volume mounted below.
+          args:
+            - "--appendonly"
+            - "yes"
+            - "--dir"
+            - "/data"
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          volumeMounts:
+            - name: keystore-data
+              mountPath: /data
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 6
+          {{- with .Values.keystore.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.keystore.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.keystore.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.keystore.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.keystore.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: keystore-data
+        {{- with .Values.keystore.persistence.annotations }}
+        # IMPORTANT: this volume must be excluded from off-cluster backups, or
+        # keys could be resurrected past their TTL and break the erasure
+        # guarantee. Set the exclusion annotation for your backup tooling here.
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- range .Values.keystore.persistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- if .Values.keystore.persistence.storageClass }}
+        storageClassName: {{ .Values.keystore.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.keystore.persistence.size | quote }}
+  {{- else }}
+      volumes:
+        - name: keystore-data
+          emptyDir: {}
+  {{- end }}
+{{- end }}

--- a/tests/keystore_test.yaml
+++ b/tests/keystore_test.yaml
@@ -3,6 +3,8 @@ templates:
   - keystore/statefulset.yaml
   - keystore/service.yaml
   - deployment.yaml
+  - secret.yaml
+  - configmap.yaml
 tests:
   - it: should not create the statefulset when keystore is disabled
     template: keystore/statefulset.yaml
@@ -42,6 +44,17 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: "redis:7.4"
+
+  - it: should render pod annotations only when set (never a bare annotations key)
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+      keystore.podAnnotations:
+        example.com/foo: bar
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["example.com/foo"]
+          value: bar
 
   - it: should enable append-only persistence via args
     template: keystore/statefulset.yaml
@@ -171,14 +184,3 @@ tests:
           content:
             name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
             value: "k1"
-
-  - it: should not inject the keystore redis_url env when disabled
-    template: deployment.yaml
-    set:
-      keystore.enabled: false
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: DWCTL_KEYSTORE__REDIS_URL
-            value: "redis://RELEASE-NAME-control-layer-keystore:6379"

--- a/tests/keystore_test.yaml
+++ b/tests/keystore_test.yaml
@@ -1,0 +1,184 @@
+suite: test keystore (ZDR key custody Redis)
+templates:
+  - keystore/statefulset.yaml
+  - keystore/service.yaml
+  - deployment.yaml
+tests:
+  - it: should not create the statefulset when keystore is disabled
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create the service when keystore is disabled
+    template: keystore/service.yaml
+    set:
+      keystore.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the statefulset with default configuration
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-keystore
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: keystore
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-control-layer-keystore
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "redis:7.4"
+
+  - it: should enable append-only persistence via args
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "--appendonly"
+            - "yes"
+            - "--dir"
+            - "/data"
+
+  - it: should mount the data volume and probe with redis-cli ping
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: keystore-data
+            mountPath: /data
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value: ["redis-cli", "ping"]
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value: ["redis-cli", "ping"]
+
+  - it: should use custom image configuration when specified
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+      keystore.image.repository: "custom-redis"
+      keystore.image.tag: "7.2"
+      keystore.image.pullPolicy: "Always"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "custom-redis:7.2"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"
+
+  - it: should create a persistent volume claim template when persistence enabled
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+      keystore.persistence.enabled: true
+      keystore.persistence.size: "2Gi"
+      keystore.persistence.storageClass: "fast-ssd"
+      keystore.persistence.accessModes:
+        - ReadWriteOnce
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: keystore-data
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: "2Gi"
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: "fast-ssd"
+      - contains:
+          path: spec.volumeClaimTemplates[0].spec.accessModes
+          content: "ReadWriteOnce"
+
+  - it: should carry the backup-exclusion annotation on the volume claim
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+      keystore.persistence.enabled: true
+      keystore.persistence.annotations:
+        backup.velero.io/backup-volumes-excludes: keystore-data
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.annotations["backup.velero.io/backup-volumes-excludes"]
+          value: keystore-data
+
+  - it: should use emptyDir when persistence is disabled
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+      keystore.persistence.enabled: false
+    asserts:
+      - isNull:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: keystore-data
+            emptyDir: {}
+
+  - it: should create the service on the redis port
+    template: keystore/service.yaml
+    set:
+      keystore.enabled: true
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-keystore
+      - contains:
+          path: spec.ports
+          content:
+            port: 6379
+            targetPort: redis
+            protocol: TCP
+            name: redis
+
+  - it: should inject the keystore redis_url and current_wrap_key_id env when enabled
+    template: deployment.yaml
+    set:
+      keystore.enabled: true
+      keystore.currentWrapKeyId: "k1"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            value: "redis://RELEASE-NAME-control-layer-keystore:6379"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
+            value: "k1"
+
+  - it: should not inject the keystore redis_url env when disabled
+    template: deployment.yaml
+    set:
+      keystore.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            value: "redis://RELEASE-NAME-control-layer-keystore:6379"

--- a/values.yaml
+++ b/values.yaml
@@ -375,6 +375,12 @@ keystore:
   # so this is "k1"). Injected into dwctl via env, so no config-blob edit needed.
   currentWrapKeyId: "k1"
 
+  # TTL (seconds) applied to both per-request keys, measured from submit. Unset
+  # leaves dwctl's default (7200 = 2h). Set it above the longest flex completion
+  # window plus a retrieval grace, or in-flight requests self-destruct before
+  # they are processed. Injected into dwctl via env when set.
+  # defaultTtlSeconds: 7200
+
   image:
     repository: redis
     pullPolicy: IfNotPresent

--- a/values.yaml
+++ b/values.yaml
@@ -35,8 +35,10 @@ secrets:
       #DWCTL_PAYMENT__STRIPE__WEBHOOK_SECRET:
       #DWCTL_PAYMENT__STRIPE__PRICE_ID:
       # ZDR keystore wrap key(s). One entry per key id; the id (uppercased) is
-      # the env suffix and must match keystore.current_wrap_key_id in the config
-      # blob (lowercased). Keep retired ids for one TTL during rotation (see the
+      # the env suffix (DWCTL_KEYSTORE__WRAP_KEYS__<ID>) and must match
+      # keystore.currentWrapKeyId below, which the chart injects as
+      # DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID (dwctl matches the two case-
+      # insensitively). Keep retired ids for one TTL during rotation (see the
       # plan's "Wrap-key rotation"). Each value is a strong random passphrase run
       # through dwctl's KDF. Only needed when keystore.enabled is true.
       #DWCTL_KEYSTORE__WRAP_KEYS__K1: "a-strong-random-passphrase"

--- a/values.yaml
+++ b/values.yaml
@@ -34,6 +34,12 @@ secrets:
       #DWCTL_PAYMENT__STRIPE__API_KEY:
       #DWCTL_PAYMENT__STRIPE__WEBHOOK_SECRET:
       #DWCTL_PAYMENT__STRIPE__PRICE_ID:
+      # ZDR keystore wrap key(s). One entry per key id; the id (uppercased) is
+      # the env suffix and must match keystore.current_wrap_key_id in the config
+      # blob (lowercased). Keep retired ids for one TTL during rotation (see the
+      # plan's "Wrap-key rotation"). Each value is a strong random passphrase run
+      # through dwctl's KDF. Only needed when keystore.enabled is true.
+      #DWCTL_KEYSTORE__WRAP_KEYS__K1: "a-strong-random-passphrase"
 
   # PostgreSQL database credentials (used if postgresql.enabled is true)
   postgres:
@@ -165,6 +171,15 @@ config: |
 
   # Secret key for session signing (set via DWCTL_SECRET_KEY environment variable)
   secret_key: "your-secret-key-here"
+
+  # ZDR keystore: nothing is needed here for a default setup. redis_url and
+  # current_wrap_key_id are injected via env (from keystore.* values), the wrap
+  # key(s) come from secrets.controlLayer.data, and default_ttl_seconds defaults
+  # to 7200s in dwctl. Uncomment only to override the TTL:
+  # keystore:
+  #   # Set above the longest flex completion window plus a retrieval grace, or
+  #   # in-flight requests self-destruct before they are processed.
+  #   default_ttl_seconds: 7200
 
 # Fusillade Daemon Configuration
 # When enabled, deploys the fusillade daemon as a separate deployment from the control layer.
@@ -328,3 +343,70 @@ postgresql:
     runAsGroup: 999
     # Security best practice - prevent running as root
     runAsNonRoot: true
+
+# ZDR keystore: a single-instance Redis holding the short-lived per-request keys
+# that decrypt zero-data-retention flex request/response bodies. The bodies are
+# stored encrypted in Postgres; the keys live here with a TTL, so a body becomes
+# permanently unreadable once its key is deleted (on retrieval) or expires
+# (crypto-shred). See zdr-flex-encryption-plan.md.
+#
+# To turn ZDR on:
+#   1. keystore.enabled: true (deploys this Redis and points dwctl at it)
+#   2. add the wrap key(s) to secrets.controlLayer.data as
+#      DWCTL_KEYSTORE__WRAP_KEYS__<ID> (see that section), and point
+#      keystore.currentWrapKeyId at the matching id
+#   3. an admin sets zero_data_retention on each target account (dashboard/admin
+#      API). Enablement is per-account, NOT an env flag - there is no
+#      DWCTL_ZDR_ALL_FLEX (setting it crashes the pod). Do steps 1-2 and verify
+#      the keystore is running BEFORE flagging any account, or that account's flex
+#      requests fail closed with a 500. Flagging also makes that account's realtime
+#      requests non-persist and rejects realtime + server-side tools.
+# redis_url and current_wrap_key_id are injected via env automatically; the TTL
+# defaults in dwctl (override in the `config` blob if needed).
+keystore:
+  # Deploy the internal keystore Redis StatefulSet. Off by default; when false,
+  # ZDR is inactive and flex bodies are stored in plaintext as before.
+  enabled: false
+
+  # Which wrap key seals new values. Must match a key id in
+  # secrets.controlLayer.data (uppercased there as DWCTL_KEYSTORE__WRAP_KEYS__K1,
+  # so this is "k1"). Injected into dwctl via env, so no config-blob edit needed.
+  currentWrapKeyId: "k1"
+
+  image:
+    repository: redis
+    pullPolicy: IfNotPresent
+    tag: "7.4"
+
+  # Data persistence (append-only file). Keys and their absolute TTLs survive a
+  # pod restart or reschedule, so the crypto-shred clock is not reset.
+  persistence:
+    # Set to false for ephemeral storage. NOT recommended: a reschedule would
+    # drop every in-flight key and fail those requests.
+    enabled: true
+    # Leave empty to use the cluster default storage class.
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    # CRITICAL: exclude this volume from off-cluster backups, or keys could be
+    # resurrected past their TTL and break the erasure guarantee. Set the
+    # exclusion annotation for your backup tooling. Example for Velero:
+    annotations: {}
+    #  backup.velero.io/backup-volumes-excludes: keystore-data
+
+  resources: {}
+
+  # Redis official image runs as uid/gid 999.
+  podSecurityContext:
+    fsGroup: 999
+  securityContext:
+    runAsUser: 999
+    runAsGroup: 999
+    runAsNonRoot: true
+
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  affinity: {}
+  tolerations: {}


### PR DESCRIPTION
# feat: add ZDR keystore (Redis) and wrap-key wiring

## What

Adds an optional, single-instance Redis "keystore" that holds the short-lived
per-request keys used by dwctl's zero-data-retention (ZDR) flex feature, plus the
wiring to connect dwctl to it. Off by default, so existing deployments are
unchanged.

Background: ZDR flex stores request/response bodies encrypted at rest in
Postgres and keeps the decryption keys in a separate store with a TTL, so a body
becomes permanently unreadable once its key is deleted (on retrieval) or expires
(crypto-shred). This chart change is the "separate store" plus its wiring. See
`zdr-flex-encryption-plan.md` in the application repo for the full design.

## Changes

- `templates/keystore/statefulset.yaml` and `service.yaml`: a Redis StatefulSet
  and ClusterIP Service, modelled on the existing `templates/postgres/` pair.
  Gated on `keystore.enabled`. Append-only file (AOF) on and a PVC-backed data
  dir, so keys and their absolute TTLs survive a pod restart or reschedule (the
  crypto-shred clock is not reset). Fixed at one replica by design - this is a
  strongly-consistent custody store, not a cache.
- `templates/deployment.yaml`: when `keystore.enabled`, injects
  `DWCTL_KEYSTORE__REDIS_URL` (pointing at the in-cluster keystore Service) and
  `DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID` (from values) into the control-layer pod.
- `templates/_helpers.tpl`: `keystore` label and selector-label helpers, mirroring
  the postgres and fusillade ones.
- `values.yaml`: a `keystore` block (enable flag, `currentWrapKeyId`, image,
  persistence, resources, security contexts, scheduling), a commented wrap-key
  example under `secrets.controlLayer.data`, and a short optional TTL-override
  note in the `config` blob.
- `tests/keystore_test.yaml`: helm-unittest coverage for the StatefulSet,
  Service, AOF args, probes, PVC (including the backup-exclusion annotation),
  emptyDir fallback, and the deployment env injection.

## How the wiring works

The wrap key is the one secret piece. It rides in the existing
`control-layer-secret` via `secrets.controlLayer.data` as
`DWCTL_KEYSTORE__WRAP_KEYS__K1` (one entry per key id), so it is injected through
the deployment's existing `envFrom` with no new Secret template. Everything else
is non-secret: `redis_url` and `current_wrap_key_id` come from the chart via env,
and `default_ttl_seconds` defaults in dwctl (2 hours). So enabling ZDR needs no
edit to the `config` blob.

## IMPORTANT: backup exclusion

The keystore PVC MUST be excluded from off-cluster backups. If keys can be
restored from a snapshot they can outlive their TTL, which breaks the erasure
guarantee. Set `keystore.persistence.annotations` to your backup tool's
exclusion annotation (a Velero example is shown, commented, in values). The
volume-claim template surfaces whatever annotations you set.

## Turning it on

1. `keystore.enabled: true`
2. Add the wrap key(s) to `secrets.controlLayer.data` as
   `DWCTL_KEYSTORE__WRAP_KEYS__K1` (a strong random passphrase), and set
   `keystore.currentWrapKeyId: k1` to match.
3. Set the backup-exclusion annotation on `keystore.persistence.annotations`.
4. Have an admin set `zero_data_retention` on each target account (dashboard or
   admin API). Enablement is per-account, not an env flag - there is no
   `DWCTL_ZDR_ALL_FLEX`. Do steps 1-3 and verify the keystore is running before
   flagging any account, or that account's flex requests fail closed with a 500.

Wrap-key rotation is an ops runbook (add a new id, promote it, wait one TTL,
retire the old id) - see the plan's "Wrap-key rotation" section.

## Testing

- `helm lint .` passes.
- `helm template` renders cleanly with the keystore off (default) and on.
- `tests/keystore_test.yaml` added (run with `helm unittest .`).

## Depends on

The application side (dwctl reading `DWCTL_KEYSTORE__*` and doing the crypto)
ships separately. This chart change is inert until an image with ZDR support is
deployed and an account is flagged for ZDR, so it is safe to land independently.
