### PR TITLE
fix: wire ZDR keystore env into the fusillade daemon

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -127,3 +127,28 @@ app.kubernetes.io/name: {{ include "control-layer.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: keystore
 {{- end }}
+
+{{/*
+ZDR keystore env wiring, shared by the control-layer and fusillade Deployments so
+the two cannot drift. The fusillade daemon is what encrypts flex bodies, so it
+needs the keystore env just as much as the API pods do. Callers guard on
+.Values.keystore.enabled and set indentation, e.g.:
+  {{- if .Values.keystore.enabled }}
+  {{- include "control-layer.keystoreEnv" . | nindent 12 }}
+  {{- end }}
+redis_url always targets the in-cluster keystore Service; current_wrap_key_id comes
+from values. The wrap key(s) themselves are the only piece the operator supplies as
+a secret (secrets.controlLayer.data: DWCTL_KEYSTORE__WRAP_KEYS__<ID>).
+default_ttl_seconds defaults in dwctl (7200s); set keystore.defaultTtlSeconds to
+override it.
+*/}}
+{{- define "control-layer.keystoreEnv" -}}
+- name: DWCTL_KEYSTORE__REDIS_URL
+  value: "redis://{{ include "control-layer.fullname" . }}-keystore:6379"
+- name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
+  value: {{ .Values.keystore.currentWrapKeyId | quote }}
+{{- with .Values.keystore.defaultTtlSeconds }}
+- name: DWCTL_KEYSTORE__DEFAULT_TTL_SECONDS
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -62,20 +62,7 @@ spec:
               value: "never"
             {{- end }}
             {{- if .Values.keystore.enabled }}
-            # ZDR keystore wiring. redis_url always points at the in-cluster
-            # keystore Service; current_wrap_key_id comes from values. The wrap
-            # key(s) themselves are the only piece the operator supplies as a
-            # secret (secrets.controlLayer.data: DWCTL_KEYSTORE__WRAP_KEYS__<ID>).
-            # default_ttl_seconds defaults in dwctl (7200s); set
-            # keystore.defaultTtlSeconds to override it.
-            - name: DWCTL_KEYSTORE__REDIS_URL
-              value: "redis://{{ include "control-layer.fullname" . }}-keystore:6379"
-            - name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
-              value: {{ .Values.keystore.currentWrapKeyId | quote }}
-            {{- with .Values.keystore.defaultTtlSeconds }}
-            - name: DWCTL_KEYSTORE__DEFAULT_TTL_SECONDS
-              value: {{ . | quote }}
-            {{- end }}
+            {{- include "control-layer.keystoreEnv" . | nindent 12 }}
             {{- end }}
             {{- with .Values.env }}
             {{- range $key, $value := . }}

--- a/templates/fusillade/deployment.yaml
+++ b/templates/fusillade/deployment.yaml
@@ -79,6 +79,9 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.keystore.enabled }}
+            {{- include "control-layer.keystoreEnv" . | nindent 12 }}
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/tests/keystore_test.yaml
+++ b/tests/keystore_test.yaml
@@ -3,6 +3,7 @@ templates:
   - keystore/statefulset.yaml
   - keystore/service.yaml
   - deployment.yaml
+  - fusillade/deployment.yaml
   - secret.yaml
   - configmap.yaml
 tests:
@@ -184,3 +185,42 @@ tests:
           content:
             name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
             value: "k1"
+
+  # The fusillade daemon is what encrypts flex bodies at rest, so it needs the
+  # same keystore env as the API pods. Regression guard: chart 1.1.0 shipped it
+  # on deployment.yaml only, crash-looping the daemon on a missing redis_url.
+  - it: should inject the keystore env into the fusillade daemon when enabled
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      keystore.enabled: true
+      keystore.currentWrapKeyId: "k1"
+      keystore.defaultTtlSeconds: 86400
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            value: "redis://RELEASE-NAME-control-layer-keystore:6379"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
+            value: "k1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__DEFAULT_TTL_SECONDS
+            value: "86400"
+
+  - it: should not inject keystore env into the fusillade daemon when disabled
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      keystore.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            value: "redis://RELEASE-NAME-control-layer-keystore:6379"


### PR DESCRIPTION
## What

Chart `1.1.0` injected the `DWCTL_KEYSTORE__*` env (`redis_url`, `current_wrap_key_id`, `default_ttl_seconds`) into the **control-layer** Deployment only. The **fusillade** daemon — the component that actually encrypts flex request/response bodies at rest — never got it, so with `keystore.enabled: true` it crash-loops on:

```
Error: missing field `redis_url` for key "KEYSTORE" in `DWCTL_` environment variable(s)
```

and no batches are processed (found on a staging deploy of the ZDR RC: keystore Redis up, web pods healthy, `control-layer-fusillade` in `CrashLoopBackOff`).

## Change

- Extract the keystore env into a shared `control-layer.keystoreEnv` helper (`_helpers.tpl`) used by **both** the control-layer and fusillade Deployments, so the two can't drift again — drift is the root cause here.
- The rendered **web** Deployment env is byte-identical; only the inline explanatory comment moves into the helper.
- Add fusillade coverage to `keystore_test.yaml`. It previously asserted only against the web Deployment — that gap is why the bug shipped. The new test **fails on 1.1.0** and passes here.

## Verification

- `helm lint` clean
- `helm unittest`: 72/72 pass (was 70; +2 fusillade cases)
- Rendered both Deployments with `keystore.enabled=true` → both now carry the three `DWCTL_KEYSTORE__*` vars with identical values; with `keystore.enabled=false` → neither does (no change when ZDR is off).

Patch release → `1.1.1`. Consumers on `keystore.enabled: true` should bump to `1.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)