### PR TITLE
feat: add managed keystore storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ When `fusillade.enabled: true`:
 - The control layer pods will have `background_services.batch_daemon.enabled` set to `never`
 - The fusillade pods will have `background_services.batch_daemon.enabled` set to `always`
 
+### Keystore Persistence with a Managed StorageClass
+
+The internal keystore can create and use a dedicated StorageClass for its Redis
+PVC. On GKE, set `disk-encryption-kms-key` to provision the backing Persistent
+Disk with a customer-managed Cloud KMS key:
+
+```yaml
+keystore:
+  enabled: true
+  persistence:
+    managedStorageClass:
+      enabled: true
+      parameters:
+        type: pd-balanced
+        disk-encryption-kms-key: projects/PROJECT_ID/locations/REGION/keyRings/KEY_RING/cryptoKeys/KEY
+```
+
+Existing PVCs keep the StorageClass they were created with. Recreate or migrate
+the keystore volume to move an existing install onto the managed StorageClass.
+
 ## Example Configurations
 
 ### With External Database

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -129,6 +129,25 @@ app.kubernetes.io/component: keystore
 {{- end }}
 
 {{/*
+Name for the chart-managed keystore StorageClass.
+*/}}
+{{- define "control-layer.keystore.storageClassName" -}}
+{{- default (printf "%s-keystore-cmek" (include "control-layer.fullname" .)) .Values.keystore.persistence.managedStorageClass.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+StorageClass selected by the keystore PVC. A managed class takes precedence over
+the legacy storageClass string because the chart also creates that class.
+*/}}
+{{- define "control-layer.keystore.persistenceStorageClassName" -}}
+{{- if .Values.keystore.persistence.managedStorageClass.enabled -}}
+{{- include "control-layer.keystore.storageClassName" . -}}
+{{- else -}}
+{{- .Values.keystore.persistence.storageClass -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 ZDR keystore env wiring, shared by the control-layer and fusillade Deployments so
 the two cannot drift. The fusillade daemon is what encrypts flex bodies, so it
 needs the keystore env just as much as the API pods do. Callers guard on

--- a/templates/keystore/statefulset.yaml
+++ b/templates/keystore/statefulset.yaml
@@ -99,8 +99,9 @@ spec:
           {{- range .Values.keystore.persistence.accessModes }}
           - {{ . | quote }}
           {{- end }}
-        {{- if .Values.keystore.persistence.storageClass }}
-        storageClassName: {{ .Values.keystore.persistence.storageClass | quote }}
+        {{- $storageClassName := include "control-layer.keystore.persistenceStorageClassName" . }}
+        {{- if $storageClassName }}
+        storageClassName: {{ $storageClassName | quote }}
         {{- end }}
         resources:
           requests:

--- a/templates/keystore/storageclass.yaml
+++ b/templates/keystore/storageclass.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.keystore.enabled .Values.keystore.persistence.enabled .Values.keystore.persistence.managedStorageClass.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ include "control-layer.keystore.storageClassName" . }}
+  labels:
+    {{- include "control-layer.keystore.labels" . | nindent 4 }}
+  {{- with .Values.keystore.persistence.managedStorageClass.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+provisioner: {{ .Values.keystore.persistence.managedStorageClass.provisioner | quote }}
+reclaimPolicy: {{ .Values.keystore.persistence.managedStorageClass.reclaimPolicy | quote }}
+volumeBindingMode: {{ .Values.keystore.persistence.managedStorageClass.volumeBindingMode | quote }}
+allowVolumeExpansion: {{ .Values.keystore.persistence.managedStorageClass.allowVolumeExpansion }}
+{{- with .Values.keystore.persistence.managedStorageClass.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/tests/keystore_test.yaml
+++ b/tests/keystore_test.yaml
@@ -2,6 +2,7 @@ suite: test keystore (ZDR key custody Redis)
 templates:
   - keystore/statefulset.yaml
   - keystore/service.yaml
+  - keystore/storageclass.yaml
   - deployment.yaml
   - fusillade/deployment.yaml
   - secret.yaml
@@ -136,6 +137,48 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].metadata.annotations["backup.velero.io/backup-volumes-excludes"]
           value: keystore-data
+
+  - it: should use the managed storage class when enabled
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+      keystore.persistence.enabled: true
+      keystore.persistence.managedStorageClass.enabled: true
+      keystore.persistence.managedStorageClass.parameters:
+        type: pd-balanced
+        disk-encryption-kms-key: projects/example/locations/europe-west2/keyRings/gke-disk-encryption/cryptoKeys/keystore
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: RELEASE-NAME-control-layer-keystore-cmek
+
+  - it: should create a managed storage class for keystore persistence
+    template: keystore/storageclass.yaml
+    set:
+      keystore.enabled: true
+      keystore.persistence.enabled: true
+      keystore.persistence.managedStorageClass.enabled: true
+      keystore.persistence.managedStorageClass.parameters:
+        type: pd-balanced
+        disk-encryption-kms-key: projects/example/locations/europe-west2/keyRings/gke-disk-encryption/cryptoKeys/keystore
+    asserts:
+      - isKind:
+          of: StorageClass
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-keystore-cmek
+      - equal:
+          path: provisioner
+          value: pd.csi.storage.gke.io
+      - equal:
+          path: parameters.type
+          value: pd-balanced
+      - equal:
+          path: parameters["disk-encryption-kms-key"]
+          value: projects/example/locations/europe-west2/keyRings/gke-disk-encryption/cryptoKeys/keystore
+      - equal:
+          path: volumeBindingMode
+          value: WaitForFirstConsumer
 
   - it: should use emptyDir when persistence is disabled
     template: keystore/statefulset.yaml

--- a/values.yaml
+++ b/values.yaml
@@ -394,6 +394,21 @@ keystore:
     enabled: true
     # Leave empty to use the cluster default storage class.
     storageClass: ""
+    # Optionally create a StorageClass for this keystore PVC and bind the PVC to
+    # it. On GKE, set parameters.disk-encryption-kms-key to a regional Cloud KMS
+    # key to provision the backing Persistent Disk with CMEK.
+    managedStorageClass:
+      enabled: false
+      # Leave empty to use "<release>-control-layer-keystore-cmek".
+      name: ""
+      provisioner: pd.csi.storage.gke.io
+      reclaimPolicy: Delete
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+      annotations: {}
+      parameters: {}
+        # type: pd-balanced
+        # disk-encryption-kms-key: projects/PROJECT_ID/locations/REGION/keyRings/KEY_RING/cryptoKeys/KEY
     accessModes:
       - ReadWriteOnce
     size: 1Gi


### PR DESCRIPTION
## Summary
- add an opt-in managed StorageClass for the keystore Redis PVC
- bind the keystore PVC to the managed class when enabled while preserving the existing storageClass value path
- document a GKE CMEK example and note that existing PVCs need recreation or migration

## Testing
- just lint
- just test
- helm template test-release . --set keystore.enabled=true --set keystore.persistence.managedStorageClass.enabled=true --set keystore.persistence.managedStorageClass.parameters.type=pd-balanced --set keystore.persistence.managedStorageClass.parameters.disk-encryption-kms-key=projects/tech-426212/locations/europe-west2/keyRings/gke-disk-encryption/cryptoKeys/curie-v4-keystore-disks