### PR TITLE
feat: support split fusillade daemon deployments

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: control-layer
 description: A Helm subchart for deploying the Doubleword control layer component
 type: application
 version: 1.2.0
-appVersion: 0.25.0
+appVersion: 8.78.0
 annotations:
   org.opencontainers.image.source: https://github.com/doublewordai/control-layer-chart
   org.opencontainers.image.description: Helm chart for deploying the Doubleword control layer service

--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ The fusillade daemon handles background batch processing tasks. By default, it r
 |-----------|-------------|---------|
 | `fusillade.enabled` | Deploy fusillade as a separate deployment | `false` |
 | `fusillade.replicaCount` | Number of fusillade replicas | `1` |
+| `fusillade.mode` | Optional daemon mode for the standard fusillade deployment (`both`, `request_only`, `batch_only`); empty uses the application default | `""` |
+| `fusillade.split.enabled` | Render separate request-only and batch-only daemon deployments | `false` |
+| `fusillade.split.request.enabled` | Render the request-only daemon deployment | `true` |
+| `fusillade.split.request.replicaCount` | Number of request daemon replicas | inherits `fusillade.replicaCount` |
+| `fusillade.split.request.resources` | CPU/Memory requests/limits for request daemon pods | inherits `fusillade.resources` |
+| `fusillade.split.request.env` | Additional environment variables for request daemon pods | merged after `env` and `fusillade.env` |
+| `fusillade.split.request.database` | Database pool overrides for request daemon pods | merged over `fusillade.database` |
+| `fusillade.split.batch.enabled` | Render the batch-only daemon deployment | `true` |
+| `fusillade.split.batch.replicaCount` | Number of batch daemon replicas | inherits `fusillade.replicaCount` |
+| `fusillade.split.batch.resources` | CPU/Memory requests/limits for batch daemon pods | inherits `fusillade.resources` |
+| `fusillade.split.batch.env` | Additional environment variables for batch daemon pods | merged after `env` and `fusillade.env` |
+| `fusillade.split.batch.database` | Database pool overrides for batch daemon pods | merged over `fusillade.database` |
 | `fusillade.image.repository` | Override image repository | (uses main image) |
 | `fusillade.image.tag` | Override image tag | (uses main image) |
 | `fusillade.resources` | CPU/Memory resource requests/limits | `{}` |
@@ -137,6 +149,8 @@ The fusillade daemon handles background batch processing tasks. By default, it r
 When `fusillade.enabled: true`:
 - The control layer pods will have `background_services.batch_daemon.enabled` set to `never`
 - The fusillade pods will have `background_services.batch_daemon.enabled` set to `always`
+- The standard fusillade deployment uses the application's default daemon mode unless `fusillade.mode` is set
+- With `fusillade.split.enabled: true`, request pods use `mode=request_only` and batch pods use `mode=batch_only`
 
 ### Keystore Persistence with a Managed StorageClass
 
@@ -214,6 +228,31 @@ fusillade:
     requests:
       cpu: 500m
       memory: 512Mi
+```
+
+### With Split Fusillade Daemons
+
+```yaml
+# split-fusillade-values.yaml
+fusillade:
+  enabled: true
+  split:
+    enabled: true
+    request:
+      replicaCount: 4
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+    batch:
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 1Gi
+      database:
+        fusillade_pool:
+          max_connections: 80
 ```
 
 ## License

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -87,23 +87,30 @@ Create the name of the service account to use
 {{/*
 Common labels for fusillade
 */}}
-{{- define "control-layer.fusillade.labels" -}}
-helm.sh/chart: {{ include "control-layer.chart" . }}
-{{ include "control-layer.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- define "control-layer.fusillade.labelsFor" -}}
+helm.sh/chart: {{ include "control-layer.chart" .root }}
+{{ include "control-layer.fusillade.selectorLabelsFor" . }}
+{{- if .root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/component: fusillade
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+{{- end }}
+
+{{- define "control-layer.fusillade.labels" -}}
+{{ include "control-layer.fusillade.labelsFor" (dict "root" . "component" "fusillade") }}
 {{- end }}
 
 {{/*
 Selector labels for fusillade
 */}}
+{{- define "control-layer.fusillade.selectorLabelsFor" -}}
+app.kubernetes.io/name: {{ include "control-layer.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
 {{- define "control-layer.fusillade.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "control-layer.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/component: fusillade
+{{ include "control-layer.fusillade.selectorLabelsFor" (dict "root" . "component" "fusillade") }}
 {{- end }}
 
 {{/*

--- a/templates/fusillade/deployment.yaml
+++ b/templates/fusillade/deployment.yaml
@@ -1,108 +1,125 @@
-{{- if .Values.fusillade.enabled }}
+{{- define "control-layer.fusillade.deployment" -}}
+{{- $root := .root -}}
+{{- $fusillade := $root.Values.fusillade -}}
+{{- $config := .config | default dict -}}
+{{- $component := .component -}}
+{{- $suffix := .suffix -}}
+{{- $mode := .mode -}}
+{{- $image := get $config "image" | default dict -}}
+{{- $baseImage := $fusillade.image | default dict -}}
+{{- $database := mergeOverwrite (deepCopy ($fusillade.database | default dict)) (get $config "database" | default dict) -}}
+{{- $podAnnotations := mergeOverwrite (deepCopy ($fusillade.podAnnotations | default dict)) (get $config "podAnnotations" | default dict) -}}
+{{- $podLabels := mergeOverwrite (deepCopy ($fusillade.podLabels | default dict)) (get $config "podLabels" | default dict) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "control-layer.fullname" . }}-fusillade
+  name: {{ include "control-layer.fullname" $root }}{{ $suffix }}
   labels:
-    {{- include "control-layer.fusillade.labels" . | nindent 4 }}
+    {{- include "control-layer.fusillade.labelsFor" (dict "root" $root "component" $component) | nindent 4 }}
 spec:
-  replicas: {{ .Values.fusillade.replicaCount }}
+  replicas: {{- if hasKey $config "replicaCount" }} {{ get $config "replicaCount" }}{{- else }} {{ $fusillade.replicaCount }}{{- end }}
   selector:
     matchLabels:
-      {{- include "control-layer.fusillade.selectorLabels" . | nindent 6 }}
+      {{- include "control-layer.fusillade.selectorLabelsFor" (dict "root" $root "component" $component) | nindent 6 }}
   template:
     metadata:
       annotations:
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- with .Values.fusillade.podAnnotations }}
+        checksum/secret: {{ include (print $root.Template.BasePath "/secret.yaml") $root | sha256sum }}
+        checksum/config: {{ include (print $root.Template.BasePath "/configmap.yaml") $root | sha256sum }}
+        {{- with $podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "control-layer.fusillade.labels" . | nindent 8 }}
-        {{- with .Values.fusillade.podLabels }}
+        {{- include "control-layer.fusillade.labelsFor" (dict "root" $root "component" $component) | nindent 8 }}
+        {{- with $podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with $root.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "control-layer.serviceAccountName" . }}
-      {{- with (.Values.fusillade.podSecurityContext | default .Values.podSecurityContext) }}
+      serviceAccountName: {{ include "control-layer.serviceAccountName" $root }}
+      {{- with (get $config "podSecurityContext" | default $fusillade.podSecurityContext | default $root.Values.podSecurityContext) }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: fusillade
-          {{- with (.Values.fusillade.securityContext | default .Values.securityContext) }}
+          {{- with (get $config "securityContext" | default $fusillade.securityContext | default $root.Values.securityContext) }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.fusillade.image.repository | default .Values.image.repository }}:{{ .Values.fusillade.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.fusillade.image.pullPolicy | default .Values.image.pullPolicy }}
+          image: "{{ get $image "repository" | default (get $baseImage "repository") | default $root.Values.image.repository }}:{{ get $image "tag" | default (get $baseImage "tag") | default $root.Values.image.tag | default $root.Chart.AppVersion }}"
+          imagePullPolicy: {{ get $image "pullPolicy" | default (get $baseImage "pullPolicy") | default $root.Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ $root.Values.service.port }}
               protocol: TCP
           envFrom:
             - secretRef:
-                name: {{ include "control-layer.fullname" . }}-secret
+                name: {{ include "control-layer.fullname" $root }}-secret
           env:
-            # Enable fusillade daemon on these pods
-            - name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__ENABLED
-              value: "always"
             {{- /* Database pool overrides for fusillade */}}
-            {{- with .Values.fusillade.database }}
-            {{- range $key, $value := .pool }}
+            {{- range $key, $value := (get $database "pool" | default dict) }}
             - name: DWCTL_DATABASE__POOL__{{ $key | upper }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- range $key, $value := .replica_pool }}
+            {{- range $key, $value := (get $database "replica_pool" | default dict) }}
             - name: DWCTL_DATABASE__REPLICA_POOL__{{ $key | upper }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- range $key, $value := .fusillade_pool }}
+            {{- range $key, $value := (get $database "fusillade_pool" | default dict) }}
             - name: DWCTL_DATABASE__FUSILLADE__POOL__{{ $key | upper }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- range $key, $value := .fusillade_replica_pool }}
+            {{- range $key, $value := (get $database "fusillade_replica_pool" | default dict) }}
             - name: DWCTL_DATABASE__FUSILLADE__REPLICA_POOL__{{ $key | upper }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- range $key, $value := .outlet_pool }}
+            {{- range $key, $value := (get $database "outlet_pool" | default dict) }}
             - name: DWCTL_DATABASE__OUTLET__POOL__{{ $key | upper }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- range $key, $value := .outlet_replica_pool }}
+            {{- range $key, $value := (get $database "outlet_replica_pool" | default dict) }}
             - name: DWCTL_DATABASE__OUTLET__REPLICA_POOL__{{ $key | upper }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- if $root.Values.keystore.enabled }}
+            {{- include "control-layer.keystoreEnv" $root | nindent 12 }}
             {{- end }}
-            {{- if .Values.keystore.enabled }}
-            {{- include "control-layer.keystoreEnv" . | nindent 12 }}
-            {{- end }}
-            {{- range $key, $value := .Values.env }}
+            {{- range $key, $value := $root.Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- range $key, $value := .Values.fusillade.env }}
+            {{- range $key, $value := $fusillade.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          {{- with .Values.fusillade.livenessProbe }}
+            {{- range $key, $value := (get $config "env" | default dict) }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            # Enable fusillade daemon on these pods
+            - name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__ENABLED
+              value: "always"
+            {{- if $mode }}
+            - name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__MODE
+              value: {{ $mode | quote }}
+            {{- end }}
+          {{- with (get $config "livenessProbe" | default $fusillade.livenessProbe) }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.fusillade.readinessProbe }}
+          {{- with (get $config "readinessProbe" | default $fusillade.readinessProbe) }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.fusillade.startupProbe }}
+          {{- with (get $config "startupProbe" | default $fusillade.startupProbe) }}
           startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (.Values.fusillade.resources | default .Values.resources) }}
+          {{- with (get $config "resources" | default $fusillade.resources | default $root.Values.resources) }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -111,32 +128,63 @@ spec:
               mountPath: /app/config.yaml
               subPath: control-layer-config.yaml
               readOnly: true
-            {{- with .Values.fusillade.volumeMounts }}
+            {{- with $fusillade.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- with .Values.volumeMounts }}
+            {{- with (get $config "volumeMounts" | default list) }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with $root.Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         - name: config
           configMap:
-            name: {{ include "control-layer.fullname" . }}-config
-        {{- with .Values.fusillade.volumes }}
+            name: {{ include "control-layer.fullname" $root }}-config
+        {{- with $fusillade.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- with .Values.volumes }}
+        {{- with (get $config "volumes" | default list) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with (.Values.fusillade.nodeSelector | default .Values.nodeSelector) }}
+        {{- with $root.Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with (get $config "nodeSelector" | default $fusillade.nodeSelector | default $root.Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (.Values.fusillade.affinity | default .Values.affinity) }}
+      {{- with (get $config "affinity" | default $fusillade.affinity | default $root.Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (.Values.fusillade.tolerations | default .Values.tolerations) }}
+      {{- with (get $config "tolerations" | default $fusillade.tolerations | default $root.Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end -}}
+
+{{- if .Values.fusillade.enabled }}
+{{- $split := .Values.fusillade.split | default dict -}}
+{{- if $split.enabled }}
+{{- $request := $split.request | default dict -}}
+{{- $batch := $split.batch | default dict -}}
+{{- $requestEnabled := true -}}
+{{- $batchEnabled := true -}}
+{{- if hasKey $request "enabled" }}{{- $requestEnabled = $request.enabled -}}{{- end -}}
+{{- if hasKey $batch "enabled" }}{{- $batchEnabled = $batch.enabled -}}{{- end -}}
+{{- $rendered := false -}}
+{{- if $requestEnabled }}
+{{- include "control-layer.fusillade.deployment" (dict "root" . "suffix" "-fusillade-request" "component" "fusillade-request" "mode" "request_only" "config" $request) }}
+{{- $rendered = true -}}
+{{- end }}
+{{- if $batchEnabled }}
+{{- if $rendered }}
+---
+{{- end }}
+{{- include "control-layer.fusillade.deployment" (dict "root" . "suffix" "-fusillade-batch" "component" "fusillade-batch" "mode" "batch_only" "config" $batch) }}
+{{- end }}
+{{- else }}
+{{- include "control-layer.fusillade.deployment" (dict "root" . "suffix" "-fusillade" "component" "fusillade" "mode" (.Values.fusillade.mode | default "") "config" dict) }}
+{{- end }}
 {{- end }}

--- a/templates/fusillade/service.yaml
+++ b/templates/fusillade/service.yaml
@@ -1,17 +1,45 @@
-{{- if .Values.fusillade.enabled }}
+{{- define "control-layer.fusillade.service" -}}
+{{- $root := .root -}}
+{{- $suffix := .suffix -}}
+{{- $component := .component -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "control-layer.fullname" . }}-fusillade
+  name: {{ include "control-layer.fullname" $root }}{{ $suffix }}
   labels:
-    {{- include "control-layer.fusillade.labels" . | nindent 4 }}
+    {{- include "control-layer.fusillade.labelsFor" (dict "root" $root "component" $component) | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ $root.Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http
   selector:
-    {{- include "control-layer.fusillade.selectorLabels" . | nindent 4 }}
+    {{- include "control-layer.fusillade.selectorLabelsFor" (dict "root" $root "component" $component) | nindent 4 }}
+{{- end -}}
+
+{{- if .Values.fusillade.enabled }}
+{{- $split := .Values.fusillade.split | default dict -}}
+{{- if $split.enabled }}
+{{- $request := $split.request | default dict -}}
+{{- $batch := $split.batch | default dict -}}
+{{- $requestEnabled := true -}}
+{{- $batchEnabled := true -}}
+{{- if hasKey $request "enabled" }}{{- $requestEnabled = $request.enabled -}}{{- end -}}
+{{- if hasKey $batch "enabled" }}{{- $batchEnabled = $batch.enabled -}}{{- end -}}
+{{- $rendered := false -}}
+{{- if $requestEnabled }}
+{{- include "control-layer.fusillade.service" (dict "root" . "suffix" "-fusillade-request" "component" "fusillade-request") }}
+{{- $rendered = true -}}
+{{- end }}
+{{- if $batchEnabled }}
+{{- if $rendered }}
+---
+{{- end }}
+{{- include "control-layer.fusillade.service" (dict "root" . "suffix" "-fusillade-batch" "component" "fusillade-batch") }}
+{{- end }}
+{{- else }}
+{{- include "control-layer.fusillade.service" (dict "root" . "suffix" "-fusillade" "component" "fusillade") }}
+{{- end }}
 {{- end }}

--- a/templates/fusillade/servicemonitor.yaml
+++ b/templates/fusillade/servicemonitor.yaml
@@ -1,26 +1,54 @@
-{{- if and .Values.fusillade.enabled .Values.serviceMonitor.enabled }}
+{{- define "control-layer.fusillade.serviceMonitor" -}}
+{{- $root := .root -}}
+{{- $suffix := .suffix -}}
+{{- $component := .component -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "control-layer.fullname" . }}-fusillade
+  name: {{ include "control-layer.fullname" $root }}{{ $suffix }}
   labels:
-    {{- include "control-layer.fusillade.labels" . | nindent 4 }}
-    {{- with .Values.serviceMonitor.labels }}
+    {{- include "control-layer.fusillade.labelsFor" (dict "root" $root "component" $component) | nindent 4 }}
+    {{- with $root.Values.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   selector:
     matchLabels:
-      {{- include "control-layer.fusillade.selectorLabels" . | nindent 6 }}
+      {{- include "control-layer.fusillade.selectorLabelsFor" (dict "root" $root "component" $component) | nindent 6 }}
   endpoints:
     - port: http
-      {{- with .Values.serviceMonitor.path }}
+      {{- with $root.Values.serviceMonitor.path }}
       path: {{ . }}
       {{- end }}
-      {{- with .Values.serviceMonitor.interval }}
+      {{- with $root.Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      {{- with $root.Values.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+{{- end -}}
+
+{{- if and .Values.fusillade.enabled .Values.serviceMonitor.enabled }}
+{{- $split := .Values.fusillade.split | default dict -}}
+{{- if $split.enabled }}
+{{- $request := $split.request | default dict -}}
+{{- $batch := $split.batch | default dict -}}
+{{- $requestEnabled := true -}}
+{{- $batchEnabled := true -}}
+{{- if hasKey $request "enabled" }}{{- $requestEnabled = $request.enabled -}}{{- end -}}
+{{- if hasKey $batch "enabled" }}{{- $batchEnabled = $batch.enabled -}}{{- end -}}
+{{- $rendered := false -}}
+{{- if $requestEnabled }}
+{{- include "control-layer.fusillade.serviceMonitor" (dict "root" . "suffix" "-fusillade-request" "component" "fusillade-request") }}
+{{- $rendered = true -}}
+{{- end }}
+{{- if $batchEnabled }}
+{{- if $rendered }}
+---
+{{- end }}
+{{- include "control-layer.fusillade.serviceMonitor" (dict "root" . "suffix" "-fusillade-batch" "component" "fusillade-batch") }}
+{{- end }}
+{{- else }}
+{{- include "control-layer.fusillade.serviceMonitor" (dict "root" . "suffix" "-fusillade" "component" "fusillade") }}
+{{- end }}
 {{- end }}

--- a/tests/fusillade_deployment_test.yaml
+++ b/tests/fusillade_deployment_test.yaml
@@ -40,6 +40,29 @@ tests:
             name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__ENABLED
             value: "always"
 
+  - it: should use the application default daemon mode for the standard fusillade deployment
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__MODE
+          any: true
+
+  - it: should allow overriding daemon mode for the standard fusillade deployment
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.mode: batch_only
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__MODE
+            value: "batch_only"
+
   - it: should set database pool env vars when fusillade.database.pool is configured
     template: fusillade/deployment.yaml
     set:
@@ -176,3 +199,152 @@ tests:
           content:
             name: DWCTL_DATABASE__POOL__MAX_CONNECTIONS
           any: true
+
+  - it: should render separate request and batch daemon deployments when split mode is enabled
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.split.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-request
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: fusillade-request
+        documentIndex: 0
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: fusillade-request
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__MODE
+            value: "request_only"
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-batch
+        documentIndex: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: fusillade-batch
+        documentIndex: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: fusillade-batch
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__MODE
+            value: "batch_only"
+        documentIndex: 1
+
+  - it: should independently configure and scale split daemon deployments
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.replicaCount: 2
+      fusillade.resources.requests.cpu: 100m
+      fusillade.database.fusillade_pool.min_connections: 2
+      fusillade.split.enabled: true
+      fusillade.split.request.replicaCount: 4
+      fusillade.split.request.resources.requests.cpu: 250m
+      fusillade.split.request.env.REQUEST_DAEMON_ONLY: "true"
+      fusillade.split.request.database.fusillade_pool.max_connections: 25
+      fusillade.split.batch.replicaCount: 1
+      fusillade.split.batch.resources.requests.cpu: 900m
+      fusillade.split.batch.env.BATCH_DAEMON_ONLY: "true"
+      fusillade.split.batch.database.fusillade_pool.max_connections: 80
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 4
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REQUEST_DAEMON_ONLY
+            value: "true"
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_DATABASE__FUSILLADE__POOL__MIN_CONNECTIONS
+            value: "2"
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_DATABASE__FUSILLADE__POOL__MAX_CONNECTIONS
+            value: "25"
+        documentIndex: 0
+      - equal:
+          path: spec.replicas
+          value: 1
+        documentIndex: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 900m
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BATCH_DAEMON_ONLY
+            value: "true"
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_DATABASE__FUSILLADE__POOL__MIN_CONNECTIONS
+            value: "2"
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_DATABASE__FUSILLADE__POOL__MAX_CONNECTIONS
+            value: "80"
+        documentIndex: 1
+
+  - it: should inherit common fusillade replica count in split mode
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.replicaCount: 3
+      fusillade.split.enabled: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+        documentIndex: 0
+      - equal:
+          path: spec.replicas
+          value: 3
+        documentIndex: 1
+
+  - it: should allow disabling one split daemon deployment
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.split.enabled: true
+      fusillade.split.batch.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-request
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__MODE
+            value: "request_only"

--- a/tests/fusillade_service_test.yaml
+++ b/tests/fusillade_service_test.yaml
@@ -1,0 +1,66 @@
+suite: test fusillade services
+templates:
+  - fusillade/service.yaml
+tests:
+  - it: should not create fusillade service when disabled
+    template: fusillade/service.yaml
+    set:
+      fusillade.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the standard fusillade service when split mode is disabled
+    template: fusillade/service.yaml
+    set:
+      fusillade.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: fusillade
+
+  - it: should create request and batch services when split mode is enabled
+    template: fusillade/service.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.split.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-request
+        documentIndex: 0
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: fusillade-request
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-batch
+        documentIndex: 1
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: fusillade-batch
+        documentIndex: 1
+
+  - it: should only create enabled split daemon services
+    template: fusillade/service.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.split.enabled: true
+      fusillade.split.request.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-batch
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: fusillade-batch

--- a/tests/fusillade_servicemonitor_test.yaml
+++ b/tests/fusillade_servicemonitor_test.yaml
@@ -1,0 +1,70 @@
+suite: test fusillade service monitors
+templates:
+  - fusillade/servicemonitor.yaml
+tests:
+  - it: should not create fusillade ServiceMonitor when monitoring is disabled
+    template: fusillade/servicemonitor.yaml
+    set:
+      fusillade.enabled: true
+      serviceMonitor.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the standard fusillade ServiceMonitor when split mode is disabled
+    template: fusillade/servicemonitor.yaml
+    set:
+      fusillade.enabled: true
+      serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: fusillade
+
+  - it: should create request and batch ServiceMonitors when split mode is enabled
+    template: fusillade/servicemonitor.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.split.enabled: true
+      serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-request
+        documentIndex: 0
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: fusillade-request
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-batch
+        documentIndex: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: fusillade-batch
+        documentIndex: 1
+
+  - it: should only create enabled split daemon ServiceMonitors
+    template: fusillade/servicemonitor.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.split.enabled: true
+      fusillade.split.batch.enabled: false
+      serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-control-layer-fusillade-request
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: fusillade-request

--- a/values.yaml
+++ b/values.yaml
@@ -195,6 +195,60 @@ fusillade:
   # Number of fusillade daemon replicas
   replicaCount: 1
 
+  # Optional daemon mode for the standard single fusillade deployment.
+  # Leave empty to use the application's default mode (both).
+  # Split mode overrides this per deployment.
+  # Options: both, request_only, batch_only
+  mode: ""
+
+  # Split the fusillade daemon into independently configurable request and batch deployments.
+  # When enabled, the chart renders:
+  #   - <release>-control-layer-fusillade-request with mode=request_only
+  #   - <release>-control-layer-fusillade-batch with mode=batch_only
+  # Each split daemon inherits the top-level fusillade settings. Scalar and map
+  # settings such as replicaCount, image, resources, pod metadata, security
+  # context, scheduling, probes, and database pools can be overridden per daemon.
+  # env is merged after global/fusillade env, while volumes and volumeMounts are
+  # appended to the top-level lists.
+  split:
+    enabled: false
+    request:
+      enabled: true
+      image: {}
+      resources: {}
+      podAnnotations: {}
+      podLabels: {}
+      podSecurityContext: {}
+      securityContext: {}
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      livenessProbe: {}
+      readinessProbe: {}
+      startupProbe: {}
+      database: {}
+      env: {}
+      volumes: []
+      volumeMounts: []
+    batch:
+      enabled: true
+      image: {}
+      resources: {}
+      podAnnotations: {}
+      podLabels: {}
+      podSecurityContext: {}
+      securityContext: {}
+      nodeSelector: {}
+      tolerations: []
+      affinity: {}
+      livenessProbe: {}
+      readinessProbe: {}
+      startupProbe: {}
+      database: {}
+      env: {}
+      volumes: []
+      volumeMounts: []
+
   # Override image settings for fusillade (defaults to main image settings)
   image: {}
     # repository: ghcr.io/doublewordai/control-layer


### PR DESCRIPTION
## Summary
- Default the chart app image to `control-layer:8.78.0`.
- Add optional `fusillade.split.enabled` chart mode that renders separate request-only and batch-only Fusillade daemon Deployments.
- Let `fusillade.split.request` and `fusillade.split.batch` override replica count, resources, env, database pool settings, scheduling, probes, pod metadata, security context, image, volumes, and volume mounts independently.
- Render split-aware Services and ServiceMonitors with non-overlapping selectors.
- Keep the existing single Fusillade Deployment path as the default; `fusillade.mode` is optional and empty by default so existing single-daemon installs keep the application default.

## Verification
- `just lint`
- `just test`
- `helm template test-release .`
- `helm template test-release . --set fusillade.enabled=true --set fusillade.split.enabled=true --set serviceMonitor.enabled=true`

## Notes
- Split mode uses `DWCTL_BACKGROUND_SERVICES__BATCH_DAEMON__MODE=request_only` and `batch_only`, so it should be used with a control-layer image that includes daemon mode config support. The chart now defaults to `8.78.0`.
