### PR TITLE
feat: support externally managed runtime secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ The named Secret must exist in the release namespace and contain
 chart does not render or mutate a Secret when `existingSecret` is set, and both
 the application and Fusillade workloads consume the same name.
 
+For a small credential that rotates independently, keep the chart-owned Secret
+and load one or more overlays after it:
+
+```yaml
+secrets:
+  controlLayer:
+    extraExistingSecrets:
+      - rotated-database
+```
+
+Kubernetes resolves duplicate `envFrom` keys from the later Secret, so overlays
+should contain only the keys they intentionally replace.
+
 The following table lists the configurable parameters and their default values. See `values.yaml` for all available options.
 
 ### Core Configuration

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ helm install my-control-layer oci://ghcr.io/doublewordai/charts/control-layer -f
 
 ## Configuration
 
+### Externally managed runtime Secret
+
+By default the chart creates `<release>-control-layer-secret` from
+`secrets.controlLayer.data`. To use a Secret managed by another controller,
+configure its name instead:
+
+```yaml
+secrets:
+  controlLayer:
+    existingSecret: externally-managed-runtime
+```
+
+The named Secret must exist in the release namespace and contain
+`DATABASE_URL` plus any other runtime keys required by the deployment. The
+chart does not render or mutate a Secret when `existingSecret` is set, and both
+the application and Fusillade workloads consume the same name.
+
 The following table lists the configurable parameters and their default values. See `values.yaml` for all available options.
 
 ### Core Configuration

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -85,6 +85,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Name of the Secret consumed by control-layer and Fusillade workloads.
+*/}}
+{{- define "control-layer.secretName" -}}
+{{- default (printf "%s-secret" (include "control-layer.fullname" .)) .Values.secrets.controlLayer.existingSecret -}}
+{{- end }}
+
+{{/*
 Common labels for fusillade
 */}}
 {{- define "control-layer.fusillade.labelsFor" -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "control-layer.secretName" . }}
+            {{- range .Values.secrets.controlLayer.extraExistingSecrets }}
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
           env:
             {{- if .Values.bootstrap.enabled }}
             - name: DASHBOARD_BOOTSTRAP_JS

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
               protocol: TCP
           envFrom:
             - secretRef:
-                name: {{ include "control-layer.fullname" . }}-secret
+                name: {{ include "control-layer.secretName" . }}
           env:
             {{- if .Values.bootstrap.enabled }}
             - name: DASHBOARD_BOOTSTRAP_JS

--- a/templates/fusillade/deployment.yaml
+++ b/templates/fusillade/deployment.yaml
@@ -59,6 +59,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "control-layer.secretName" $root }}
+            {{- range $root.Values.secrets.controlLayer.extraExistingSecrets }}
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
           env:
             {{- /* Database pool overrides for fusillade */}}
             {{- range $key, $value := (get $database "pool" | default dict) }}

--- a/templates/fusillade/deployment.yaml
+++ b/templates/fusillade/deployment.yaml
@@ -58,7 +58,7 @@ spec:
               protocol: TCP
           envFrom:
             - secretRef:
-                name: {{ include "control-layer.fullname" $root }}-secret
+                name: {{ include "control-layer.secretName" $root }}
           env:
             {{- /* Database pool overrides for fusillade */}}
             {{- range $key, $value := (get $database "pool" | default dict) }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.secrets.controlLayer.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "control-layer.fullname" . }}-secret
+  name: {{ include "control-layer.secretName" . }}
   labels:
     {{- include "control-layer.labels" . | nindent 4 }}
 type: Opaque
@@ -19,4 +20,4 @@ stringData:
   {{- end }}
   {{- end }}
   DATABASE_URL: {{ $dbUrl | quote }}
-
+{{- end }}

--- a/tests/control_layer_deployment_test.yaml
+++ b/tests/control_layer_deployment_test.yaml
@@ -55,6 +55,17 @@ tests:
             secretRef:
               name: RELEASE-NAME-control-layer-secret
 
+  - it: should consume an existing runtime secret
+    template: deployment.yaml
+    set:
+      secrets.controlLayer.existingSecret: externally-managed-runtime
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: externally-managed-runtime
+
   - it: should use correct labels and selectors
     template: deployment.yaml
     asserts:
@@ -67,4 +78,3 @@ tests:
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/component"]
           value: control-layer
-

--- a/tests/control_layer_deployment_test.yaml
+++ b/tests/control_layer_deployment_test.yaml
@@ -66,6 +66,23 @@ tests:
             secretRef:
               name: externally-managed-runtime
 
+  - it: should load overlay secrets after the primary secret
+    template: deployment.yaml
+    set:
+      secrets.controlLayer.extraExistingSecrets:
+        - rotated-database
+        - ephemeral-token
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: RELEASE-NAME-control-layer-secret
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: rotated-database
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[2].secretRef.name
+          value: ephemeral-token
+
   - it: should use correct labels and selectors
     template: deployment.yaml
     asserts:

--- a/tests/fusillade_deployment_test.yaml
+++ b/tests/fusillade_deployment_test.yaml
@@ -41,6 +41,17 @@ tests:
             secretRef:
               name: externally-managed-runtime
 
+  - it: should load control layer overlay secrets in order
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      secrets.controlLayer.extraExistingSecrets:
+        - rotated-database
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: rotated-database
+
   - it: should always enable batch daemon via env var
     template: fusillade/deployment.yaml
     set:

--- a/tests/fusillade_deployment_test.yaml
+++ b/tests/fusillade_deployment_test.yaml
@@ -29,6 +29,18 @@ tests:
           path: metadata.labels["app.kubernetes.io/component"]
           value: fusillade
 
+  - it: should consume the control layer existing runtime secret
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      secrets.controlLayer.existingSecret: externally-managed-runtime
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: externally-managed-runtime
+
   - it: should always enable batch daemon via env var
     template: fusillade/deployment.yaml
     set:

--- a/tests/secrets_test.yaml
+++ b/tests/secrets_test.yaml
@@ -60,6 +60,14 @@ tests:
       - isNull:
           path: stringData.EMPTY_VALUE
 
+  - it: should not create a control-layer secret when an existing secret is configured
+    set:
+      secrets.controlLayer.existingSecret: externally-managed-runtime
+    template: secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
   # PostgreSQL Secret Tests
   - it: should create postgres secret with credentials
     set:

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,10 @@ secrets:
     # rendered and all control-layer/Fusillade pods load this Secret instead.
     # The Secret must contain DATABASE_URL and any other required runtime keys.
     existingSecret: ""
+    # Additional Secrets loaded after the primary Secret. Kubernetes resolves
+    # duplicate envFrom keys from the later source, which is useful for small
+    # credentials that rotate independently from the chart-owned Secret.
+    extraExistingSecrets: []
     data:
       # DATABASE_URL will be templated in secret.yaml for internal PostgreSQL (if empty)
       # For external PostgreSQL, override with your external connection string

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,10 @@ serviceAccount:
 # Service-specific secrets configuration
 secrets:
   controlLayer:
-    # Whether to create this secret. If its not created, it ought to exist as name with these values
+    # Reuse a Secret managed outside this chart. When set, secret.yaml is not
+    # rendered and all control-layer/Fusillade pods load this Secret instead.
+    # The Secret must contain DATABASE_URL and any other required runtime keys.
+    existingSecret: ""
     data:
       # DATABASE_URL will be templated in secret.yaml for internal PostgreSQL (if empty)
       # For external PostgreSQL, override with your external connection string


### PR DESCRIPTION
## Summary

- allow the control-layer and Fusillade workloads to consume a named externally managed Secret without rendering a duplicate chart-owned Secret
- allow ordered additional Secret overlays after the primary runtime Secret
- document both values and cover the control-layer and split/legacy Fusillade paths with chart tests

## Why

Runtime credentials can rotate independently from a chart release. These values keep the chart declarative while allowing a separate controller to own the Secret lifecycle and preserving deterministic environment-variable precedence.

## Validation

- `just lint`
- `just test` (93 Helm unit tests)
- default, ServiceMonitor, and external-database template renders