### PR TITLE
feat: support external keystore Redis services

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,12 @@ When `fusillade.enabled: true`:
 - The standard fusillade deployment uses the application's default daemon mode unless `fusillade.mode` is set
 - With `fusillade.split.enabled: true`, request pods use `mode=request_only` and batch pods use `mode=batch_only`
 
-### Keystore Persistence with a Managed StorageClass
+### Keystore Redis
 
-The internal keystore can create and use a dedicated StorageClass for its Redis
-PVC. On GKE, set `disk-encryption-kms-key` to provision the backing Persistent
-Disk with a customer-managed Cloud KMS key:
+Enabling the ZDR keystore deploys a single-instance Redis StatefulSet and
+Service by default. The internal keystore can create and use a dedicated
+StorageClass for its Redis PVC. On GKE, set `disk-encryption-kms-key` to
+provision the backing Persistent Disk with a customer-managed Cloud KMS key:
 
 ```yaml
 keystore:
@@ -201,6 +202,40 @@ keystore:
 
 Existing PVCs keep the StorageClass they were created with. Recreate or migrate
 the keystore volume to move an existing install onto the managed StorageClass.
+
+To use a separately managed Redis service, first create a Secret in the release
+namespace containing the complete connection URL. The resulting Secret must
+have this shape; supply its value through your secret-management workflow and
+do not commit the populated manifest:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-keystore
+type: Opaque
+data:
+  redis-url: <base64-encoded-redis-connection-url>
+```
+
+Then enable external mode and reference the Secret:
+
+```yaml
+keystore:
+  enabled: true
+  external:
+    enabled: true
+    existingSecret: external-keystore
+    existingSecretKey: redis-url
+```
+
+External mode does not render the internal Redis StatefulSet, Service, or
+managed StorageClass. Both the control layer and Fusillade workloads read
+`DWCTL_KEYSTORE__REDIS_URL` directly from the Secret; the connection URL is not
+placed in ordinary Helm values or rendered manifests. Provision and validate
+the external service and Secret before enabling this mode. The chart passes the
+URL through unchanged, so the selected application image must support the
+provider's Redis URL scheme, TLS configuration, and authentication method.
 
 ## Example Configurations
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -177,12 +177,13 @@ default_ttl_seconds defaults in dwctl (7200s); set keystore.defaultTtlSeconds to
 override it.
 */}}
 {{- define "control-layer.keystoreEnv" -}}
+{{- $external := .Values.keystore.external | default dict -}}
 - name: DWCTL_KEYSTORE__REDIS_URL
-{{- if .Values.keystore.external.enabled }}
+{{- if $external.enabled }}
   valueFrom:
     secretKeyRef:
-      name: {{ required "keystore.external.existingSecret is required when external keystore is enabled" .Values.keystore.external.existingSecret | quote }}
-      key: {{ required "keystore.external.existingSecretKey is required when external keystore is enabled" .Values.keystore.external.existingSecretKey | quote }}
+      name: {{ required "keystore.external.existingSecret is required when external keystore is enabled" $external.existingSecret | quote }}
+      key: {{ required "keystore.external.existingSecretKey is required when external keystore is enabled" $external.existingSecretKey | quote }}
 {{- else }}
   value: "redis://{{ include "control-layer.fullname" . }}-keystore:6379"
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -169,15 +169,23 @@ needs the keystore env just as much as the API pods do. Callers guard on
   {{- if .Values.keystore.enabled }}
   {{- include "control-layer.keystoreEnv" . | nindent 12 }}
   {{- end }}
-redis_url always targets the in-cluster keystore Service; current_wrap_key_id comes
-from values. The wrap key(s) themselves are the only piece the operator supplies as
-a secret (secrets.controlLayer.data: DWCTL_KEYSTORE__WRAP_KEYS__<ID>).
+redis_url targets the in-cluster keystore Service by default. In external mode it
+is sourced from an existing Secret so credentials never pass through ordinary
+Helm values. current_wrap_key_id comes from values. The wrap key(s) are supplied
+as secrets.controlLayer.data: DWCTL_KEYSTORE__WRAP_KEYS__<ID>.
 default_ttl_seconds defaults in dwctl (7200s); set keystore.defaultTtlSeconds to
 override it.
 */}}
 {{- define "control-layer.keystoreEnv" -}}
 - name: DWCTL_KEYSTORE__REDIS_URL
+{{- if .Values.keystore.external.enabled }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ required "keystore.external.existingSecret is required when external keystore is enabled" .Values.keystore.external.existingSecret | quote }}
+      key: {{ required "keystore.external.existingSecretKey is required when external keystore is enabled" .Values.keystore.external.existingSecretKey | quote }}
+{{- else }}
   value: "redis://{{ include "control-layer.fullname" . }}-keystore:6379"
+{{- end }}
 - name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
   value: {{ .Values.keystore.currentWrapKeyId | quote }}
 {{- with .Values.keystore.defaultTtlSeconds }}

--- a/templates/keystore/service.yaml
+++ b/templates/keystore/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.keystore.enabled }}
+{{- if and .Values.keystore.enabled (not .Values.keystore.external.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/templates/keystore/service.yaml
+++ b/templates/keystore/service.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.keystore.enabled (not .Values.keystore.external.enabled) }}
+{{- $external := .Values.keystore.external | default dict -}}
+{{- if and .Values.keystore.enabled (not ($external.enabled | default false)) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/templates/keystore/statefulset.yaml
+++ b/templates/keystore/statefulset.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.keystore.enabled (not .Values.keystore.external.enabled) }}
+{{- $external := .Values.keystore.external | default dict -}}
+{{- if and .Values.keystore.enabled (not ($external.enabled | default false)) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/templates/keystore/statefulset.yaml
+++ b/templates/keystore/statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.keystore.enabled }}
+{{- if and .Values.keystore.enabled (not .Values.keystore.external.enabled) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/templates/keystore/storageclass.yaml
+++ b/templates/keystore/storageclass.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.keystore.enabled (not .Values.keystore.external.enabled) .Values.keystore.persistence.enabled .Values.keystore.persistence.managedStorageClass.enabled }}
+{{- $external := .Values.keystore.external | default dict -}}
+{{- if and .Values.keystore.enabled (not ($external.enabled | default false)) .Values.keystore.persistence.enabled .Values.keystore.persistence.managedStorageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/templates/keystore/storageclass.yaml
+++ b/templates/keystore/storageclass.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.keystore.enabled .Values.keystore.persistence.enabled .Values.keystore.persistence.managedStorageClass.enabled }}
+{{- if and .Values.keystore.enabled (not .Values.keystore.external.enabled) .Values.keystore.persistence.enabled .Values.keystore.persistence.managedStorageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/tests/keystore_test.yaml
+++ b/tests/keystore_test.yaml
@@ -24,6 +24,38 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should not create the internal statefulset in external mode
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+      keystore.external.enabled: true
+      keystore.external.existingSecret: external-keystore
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create the internal service in external mode
+    template: keystore/service.yaml
+    set:
+      keystore.enabled: true
+      keystore.external.enabled: true
+      keystore.external.existingSecret: external-keystore
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create the managed storage class in external mode
+    template: keystore/storageclass.yaml
+    set:
+      keystore.enabled: true
+      keystore.external.enabled: true
+      keystore.external.existingSecret: external-keystore
+      keystore.persistence.enabled: true
+      keystore.persistence.managedStorageClass.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should create the statefulset with default configuration
     template: keystore/statefulset.yaml
     set:
@@ -229,6 +261,49 @@ tests:
             name: DWCTL_KEYSTORE__CURRENT_WRAP_KEY_ID
             value: "k1"
 
+  - it: should inject the external redis_url from a secret
+    template: deployment.yaml
+    set:
+      keystore.enabled: true
+      keystore.external.enabled: true
+      keystore.external.existingSecret: external-keystore
+      keystore.external.existingSecretKey: connection-url
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: external-keystore
+                key: connection-url
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            value: "redis://RELEASE-NAME-control-layer-keystore:6379"
+
+  - it: should require an external redis secret name
+    template: deployment.yaml
+    set:
+      keystore.enabled: true
+      keystore.external.enabled: true
+      keystore.external.existingSecret: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "keystore.external.existingSecret is required when external keystore is enabled"
+
+  - it: should require an external redis secret key
+    template: deployment.yaml
+    set:
+      keystore.enabled: true
+      keystore.external.enabled: true
+      keystore.external.existingSecret: external-keystore
+      keystore.external.existingSecretKey: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "keystore.external.existingSecretKey is required when external keystore is enabled"
+
   # The fusillade daemon is what encrypts flex bodies at rest, so it needs the
   # same keystore env as the API pods. Regression guard: chart 1.1.0 shipped it
   # on deployment.yaml only, crash-looping the daemon on a missing redis_url.
@@ -255,6 +330,29 @@ tests:
           content:
             name: DWCTL_KEYSTORE__DEFAULT_TTL_SECONDS
             value: "86400"
+
+  - it: should inject the external redis_url into the fusillade daemon
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      keystore.enabled: true
+      keystore.external.enabled: true
+      keystore.external.existingSecret: external-keystore
+      keystore.external.existingSecretKey: connection-url
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: external-keystore
+                key: connection-url
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            value: "redis://RELEASE-NAME-control-layer-keystore:6379"
 
   - it: should not inject keystore env into the fusillade daemon when disabled
     template: fusillade/deployment.yaml

--- a/tests/keystore_test.yaml
+++ b/tests/keystore_test.yaml
@@ -56,6 +56,35 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should render the internal statefulset with legacy null external values
+    template: keystore/statefulset.yaml
+    set:
+      keystore.enabled: true
+      keystore.external: null
+    asserts:
+      - isKind:
+          of: StatefulSet
+
+  - it: should render the internal service with legacy null external values
+    template: keystore/service.yaml
+    set:
+      keystore.enabled: true
+      keystore.external: null
+    asserts:
+      - isKind:
+          of: Service
+
+  - it: should render the managed storage class with legacy null external values
+    template: keystore/storageclass.yaml
+    set:
+      keystore.enabled: true
+      keystore.external: null
+      keystore.persistence.enabled: true
+      keystore.persistence.managedStorageClass.enabled: true
+    asserts:
+      - isKind:
+          of: StorageClass
+
   - it: should create the statefulset with default configuration
     template: keystore/statefulset.yaml
     set:
@@ -283,6 +312,18 @@ tests:
             name: DWCTL_KEYSTORE__REDIS_URL
             value: "redis://RELEASE-NAME-control-layer-keystore:6379"
 
+  - it: should retain the internal redis_url with legacy null external values
+    template: deployment.yaml
+    set:
+      keystore.enabled: true
+      keystore.external: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            value: "redis://RELEASE-NAME-control-layer-keystore:6379"
+
   - it: should require an external redis secret name
     template: deployment.yaml
     set:
@@ -353,6 +394,37 @@ tests:
           content:
             name: DWCTL_KEYSTORE__REDIS_URL
             value: "redis://RELEASE-NAME-control-layer-keystore:6379"
+
+  - it: should inject the external redis_url into both split fusillade daemons
+    template: fusillade/deployment.yaml
+    set:
+      fusillade.enabled: true
+      fusillade.split.enabled: true
+      keystore.enabled: true
+      keystore.external.enabled: true
+      keystore.external.existingSecret: external-keystore
+      keystore.external.existingSecretKey: connection-url
+    asserts:
+      - hasDocuments:
+          count: 2
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: external-keystore
+                key: connection-url
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DWCTL_KEYSTORE__REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: external-keystore
+                key: connection-url
+        documentIndex: 1
 
   - it: should not inject keystore env into the fusillade daemon when disabled
     template: fusillade/deployment.yaml

--- a/values.yaml
+++ b/values.yaml
@@ -414,7 +414,8 @@ postgresql:
 # (crypto-shred). See zdr-flex-encryption-plan.md.
 #
 # To turn ZDR on:
-#   1. keystore.enabled: true (deploys this Redis and points dwctl at it)
+#   1. keystore.enabled: true (uses the internal Redis by default; configure
+#      keystore.external to use an existing Redis service instead)
 #   2. add the wrap key(s) to secrets.controlLayer.data as
 #      DWCTL_KEYSTORE__WRAP_KEYS__<ID> (see that section), and point
 #      keystore.currentWrapKeyId at the matching id
@@ -427,9 +428,20 @@ postgresql:
 # redis_url and current_wrap_key_id are injected via env automatically; the TTL
 # defaults in dwctl (override in the `config` blob if needed).
 keystore:
-  # Deploy the internal keystore Redis StatefulSet. Off by default; when false,
-  # ZDR is inactive and flex bodies are stored in plaintext as before.
+  # Enable the ZDR keystore. This deploys an internal Redis StatefulSet unless
+  # external.enabled is true. Off by default; when false, ZDR is inactive and
+  # flex bodies are stored in plaintext as before.
   enabled: false
+
+  # Use a separately managed Redis service instead of deploying the internal
+  # Redis StatefulSet, Service, and managed StorageClass. Create this Secret
+  # before enabling external mode; its value must be a Redis connection URL
+  # supported by the application image (for example, redis:// or rediss://).
+  # Keep credentials in the Secret rather than passing the URL through values.
+  external:
+    enabled: false
+    existingSecret: ""
+    existingSecretKey: redis-url
 
   # Which wrap key seals new values. Must match a key id in
   # secrets.controlLayer.data (uppercased there as DWCTL_KEYSTORE__WRAP_KEYS__K1,


### PR DESCRIPTION
## Summary

- add an opt-in external keystore mode backed by an existing Kubernetes Secret
- omit the embedded Redis StatefulSet, Service, and managed StorageClass when external mode is enabled
- keep the default embedded Redis behavior and legacy null values compatible
- document the Secret contract and application compatibility boundary

## Security

The Redis connection URL is consumed with secretKeyRef and is never placed in ordinary Helm values or rendered as a literal environment value.

## Verification

- just lint
- just test (105 tests)
- external API and split Fusillade render checks
- legacy null external values render check
- missing external Secret validation check