### PR TITLE
feat: add graceful rollout controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ delay keeps the process alive while Service and ingress routing converge, after
 which the control layer receives `SIGTERM` and uses its application-level
 graceful shutdown path. The termination grace supports requests lasting up to
 `connectionDrainTimeoutSeconds`, with additional time for endpoint propagation
-and cleanup.
+and cleanup. Keep `connectionDrainTimeoutSeconds` at `3600`: it mirrors the
+application's fixed maximum request wait and is validated rather than passed to
+the process as runtime configuration.
 
 `maxUnavailable: 0` and `maxSurge: 1` temporarily require capacity for one
 extra control-layer Pod. These settings apply only to the request-serving

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ rollout:
       maxUnavailable: 0
       maxSurge: 1
   endpointDrainDelaySeconds: 15
+  connectionDrainTimeoutSeconds: 3600
   terminationGracePeriodSeconds: 3700
   minReadySeconds: 15
   progressDeadlineSeconds: 4200
@@ -169,7 +170,8 @@ Kubernetes first marks the old Pod endpoint as terminating. The `preStop`
 delay keeps the process alive while Service and ingress routing converge, after
 which the control layer receives `SIGTERM` and uses its application-level
 graceful shutdown path. The termination grace supports requests lasting up to
-one hour, with additional time for endpoint propagation and cleanup.
+`connectionDrainTimeoutSeconds`, with additional time for endpoint propagation
+and cleanup.
 
 `maxUnavailable: 0` and `maxSurge: 1` temporarily require capacity for one
 extra control-layer Pod. These settings apply only to the request-serving

--- a/README.md
+++ b/README.md
@@ -146,6 +146,40 @@ The chart supports both internal and external PostgreSQL databases:
 | `volumes` | Additional volumes | `[]` |
 | `volumeMounts` | Additional volume mounts | `[]` |
 
+### Graceful rollouts
+
+Long-running request handlers can be preserved during a Deployment rollout by
+enabling the opt-in rollout contract:
+
+```yaml
+rollout:
+  enabled: true
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  endpointDrainDelaySeconds: 15
+  terminationGracePeriodSeconds: 3700
+  minReadySeconds: 15
+  progressDeadlineSeconds: 4200
+```
+
+Kubernetes first marks the old Pod endpoint as terminating. The `preStop`
+delay keeps the process alive while Service and ingress routing converge, after
+which the control layer receives `SIGTERM` and uses its application-level
+graceful shutdown path. The termination grace supports requests lasting up to
+one hour, with additional time for endpoint propagation and cleanup.
+
+`maxUnavailable: 0` and `maxSurge: 1` temporarily require capacity for one
+extra control-layer Pod. These settings apply only to the request-serving
+Deployment; Fusillade workers retain their independent shutdown and recovery
+behavior.
+
+The progress deadline must be greater than the termination grace, and the
+termination grace must be greater than the endpoint drain delay. The chart
+rejects enabled configurations that violate either requirement.
+
 ### Fusillade Daemon Configuration
 
 The fusillade daemon handles background batch processing tasks. By default, it runs within the control layer pods based on leader election. You can optionally deploy it as a separate deployment for better resource isolation and independent scaling.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,3 +1,11 @@
+{{- if .Values.rollout.enabled }}
+{{- if le (int .Values.rollout.terminationGracePeriodSeconds) (int .Values.rollout.endpointDrainDelaySeconds) }}
+{{- fail "rollout.terminationGracePeriodSeconds must be greater than rollout.endpointDrainDelaySeconds" }}
+{{- end }}
+{{- if le (int .Values.rollout.progressDeadlineSeconds) (int .Values.rollout.terminationGracePeriodSeconds) }}
+{{- fail "rollout.progressDeadlineSeconds must be greater than rollout.terminationGracePeriodSeconds" }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,6 +14,12 @@ metadata:
     {{- include "control-layer.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.rollout.enabled }}
+  strategy:
+    {{- toYaml .Values.rollout.strategy | nindent 4 }}
+  minReadySeconds: {{ .Values.rollout.minReadySeconds }}
+  progressDeadlineSeconds: {{ .Values.rollout.progressDeadlineSeconds }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "control-layer.selectorLabels" . | nindent 6 }}
@@ -24,6 +38,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.rollout.enabled }}
+      terminationGracePeriodSeconds: {{ .Values.rollout.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -35,6 +52,15 @@ spec:
       {{- end }}
       containers:
         - name: control-layer
+          {{- if .Values.rollout.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - sleep {{ .Values.rollout.endpointDrainDelaySeconds }}
+          {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,9 +1,21 @@
 {{- if .Values.rollout.enabled }}
+{{- if or (lt (int .Values.rollout.endpointDrainDelaySeconds) 0) (le (int .Values.rollout.connectionDrainTimeoutSeconds) 0) (lt (int .Values.rollout.minReadySeconds) 0) }}
+{{- fail "rollout timing values must be non-negative and connectionDrainTimeoutSeconds must be positive" }}
+{{- end }}
+{{- if or (ne .Values.rollout.strategy.type "RollingUpdate") (ne (toString .Values.rollout.strategy.rollingUpdate.maxUnavailable) "0") (ne (toString .Values.rollout.strategy.rollingUpdate.maxSurge) "1") }}
+{{- fail "rollout.strategy must use RollingUpdate with maxUnavailable 0 and maxSurge 1" }}
+{{- end }}
 {{- if le (int .Values.rollout.terminationGracePeriodSeconds) (int .Values.rollout.endpointDrainDelaySeconds) }}
 {{- fail "rollout.terminationGracePeriodSeconds must be greater than rollout.endpointDrainDelaySeconds" }}
 {{- end }}
+{{- if le (int .Values.rollout.terminationGracePeriodSeconds) (add (int .Values.rollout.endpointDrainDelaySeconds) (int .Values.rollout.connectionDrainTimeoutSeconds)) }}
+{{- fail "rollout.terminationGracePeriodSeconds must exceed rollout.endpointDrainDelaySeconds plus rollout.connectionDrainTimeoutSeconds" }}
+{{- end }}
 {{- if le (int .Values.rollout.progressDeadlineSeconds) (int .Values.rollout.terminationGracePeriodSeconds) }}
 {{- fail "rollout.progressDeadlineSeconds must be greater than rollout.terminationGracePeriodSeconds" }}
+{{- end }}
+{{- if le (int .Values.rollout.progressDeadlineSeconds) (int .Values.rollout.minReadySeconds) }}
+{{- fail "rollout.progressDeadlineSeconds must be greater than rollout.minReadySeconds" }}
 {{- end }}
 {{- end }}
 apiVersion: apps/v1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,6 +2,9 @@
 {{- if or (lt (int .Values.rollout.endpointDrainDelaySeconds) 0) (le (int .Values.rollout.connectionDrainTimeoutSeconds) 0) (lt (int .Values.rollout.minReadySeconds) 0) }}
 {{- fail "rollout timing values must be non-negative and connectionDrainTimeoutSeconds must be positive" }}
 {{- end }}
+{{- if ne (int .Values.rollout.connectionDrainTimeoutSeconds) 3600 }}
+{{- fail "rollout.connectionDrainTimeoutSeconds must be 3600 to match the control-layer request timeout" }}
+{{- end }}
 {{- if or (ne .Values.rollout.strategy.type "RollingUpdate") (ne (toString .Values.rollout.strategy.rollingUpdate.maxUnavailable) "0") (ne (toString .Values.rollout.strategy.rollingUpdate.maxSurge) "1") }}
 {{- fail "rollout.strategy must use RollingUpdate with maxUnavailable 0 and maxSurge 1" }}
 {{- end }}

--- a/tests/control_layer_deployment_test.yaml
+++ b/tests/control_layer_deployment_test.yaml
@@ -95,3 +95,74 @@ tests:
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/component"]
           value: control-layer
+
+  - it: should preserve the existing rollout behavior by default
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.strategy
+      - notExists:
+          path: spec.minReadySeconds
+      - notExists:
+          path: spec.progressDeadlineSeconds
+      - notExists:
+          path: spec.template.spec.terminationGracePeriodSeconds
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+
+  - it: should render the aligned graceful rollout contract when enabled
+    template: deployment.yaml
+    set:
+      rollout.enabled: true
+      rollout.strategy.type: RollingUpdate
+      rollout.strategy.rollingUpdate.maxUnavailable: 0
+      rollout.strategy.rollingUpdate.maxSurge: 1
+      rollout.endpointDrainDelaySeconds: 15
+      rollout.terminationGracePeriodSeconds: 3700
+      rollout.minReadySeconds: 15
+      rollout.progressDeadlineSeconds: 4200
+    asserts:
+      - equal:
+          path: spec.strategy
+          value:
+            type: RollingUpdate
+            rollingUpdate:
+              maxUnavailable: 0
+              maxSurge: 1
+      - equal:
+          path: spec.minReadySeconds
+          value: 15
+      - equal:
+          path: spec.progressDeadlineSeconds
+          value: 4200
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 3700
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - /bin/sh
+            - -c
+            - sleep 15
+
+  - it: should reject a grace period that cannot outlast endpoint draining
+    template: deployment.yaml
+    set:
+      rollout.enabled: true
+      rollout.endpointDrainDelaySeconds: 15
+      rollout.terminationGracePeriodSeconds: 15
+      rollout.progressDeadlineSeconds: 4200
+    asserts:
+      - failedTemplate:
+          errorMessage: rollout.terminationGracePeriodSeconds must be greater than rollout.endpointDrainDelaySeconds
+
+  - it: should reject a progress deadline that cannot outlast graceful termination
+    template: deployment.yaml
+    set:
+      rollout.enabled: true
+      rollout.endpointDrainDelaySeconds: 15
+      rollout.terminationGracePeriodSeconds: 3700
+      rollout.progressDeadlineSeconds: 3700
+    asserts:
+      - failedTemplate:
+          errorMessage: rollout.progressDeadlineSeconds must be greater than rollout.terminationGracePeriodSeconds

--- a/tests/control_layer_deployment_test.yaml
+++ b/tests/control_layer_deployment_test.yaml
@@ -208,3 +208,15 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: rollout timing values must be non-negative and connectionDrainTimeoutSeconds must be positive
+
+  - it: should require the control-layer application drain duration
+    template: deployment.yaml
+    set:
+      rollout.enabled: true
+      rollout.endpointDrainDelaySeconds: 15
+      rollout.connectionDrainTimeoutSeconds: 1
+      rollout.terminationGracePeriodSeconds: 3700
+      rollout.progressDeadlineSeconds: 4200
+    asserts:
+      - failedTemplate:
+          errorMessage: rollout.connectionDrainTimeoutSeconds must be 3600 to match the control-layer request timeout

--- a/tests/control_layer_deployment_test.yaml
+++ b/tests/control_layer_deployment_test.yaml
@@ -118,6 +118,7 @@ tests:
       rollout.strategy.rollingUpdate.maxUnavailable: 0
       rollout.strategy.rollingUpdate.maxSurge: 1
       rollout.endpointDrainDelaySeconds: 15
+      rollout.connectionDrainTimeoutSeconds: 3600
       rollout.terminationGracePeriodSeconds: 3700
       rollout.minReadySeconds: 15
       rollout.progressDeadlineSeconds: 4200
@@ -150,6 +151,7 @@ tests:
     set:
       rollout.enabled: true
       rollout.endpointDrainDelaySeconds: 15
+      rollout.connectionDrainTimeoutSeconds: 3600
       rollout.terminationGracePeriodSeconds: 15
       rollout.progressDeadlineSeconds: 4200
     asserts:
@@ -161,8 +163,48 @@ tests:
     set:
       rollout.enabled: true
       rollout.endpointDrainDelaySeconds: 15
+      rollout.connectionDrainTimeoutSeconds: 3600
       rollout.terminationGracePeriodSeconds: 3700
       rollout.progressDeadlineSeconds: 3700
     asserts:
       - failedTemplate:
           errorMessage: rollout.progressDeadlineSeconds must be greater than rollout.terminationGracePeriodSeconds
+
+  - it: should reject a grace period shorter than the complete request drain
+    template: deployment.yaml
+    set:
+      rollout.enabled: true
+      rollout.endpointDrainDelaySeconds: 15
+      rollout.connectionDrainTimeoutSeconds: 3600
+      rollout.terminationGracePeriodSeconds: 3615
+      rollout.progressDeadlineSeconds: 4200
+    asserts:
+      - failedTemplate:
+          errorMessage: rollout.terminationGracePeriodSeconds must exceed rollout.endpointDrainDelaySeconds plus rollout.connectionDrainTimeoutSeconds
+
+  - it: should reject a rolling strategy that can remove serving capacity
+    template: deployment.yaml
+    set:
+      rollout.enabled: true
+      rollout.strategy.type: RollingUpdate
+      rollout.strategy.rollingUpdate.maxUnavailable: 1
+      rollout.strategy.rollingUpdate.maxSurge: 1
+      rollout.endpointDrainDelaySeconds: 15
+      rollout.connectionDrainTimeoutSeconds: 3600
+      rollout.terminationGracePeriodSeconds: 3700
+      rollout.progressDeadlineSeconds: 4200
+    asserts:
+      - failedTemplate:
+          errorMessage: rollout.strategy must use RollingUpdate with maxUnavailable 0 and maxSurge 1
+
+  - it: should reject negative rollout timings
+    template: deployment.yaml
+    set:
+      rollout.enabled: true
+      rollout.endpointDrainDelaySeconds: -1
+      rollout.connectionDrainTimeoutSeconds: 3600
+      rollout.terminationGracePeriodSeconds: 3700
+      rollout.progressDeadlineSeconds: 4200
+    asserts:
+      - failedTemplate:
+          errorMessage: rollout timing values must be non-negative and connectionDrainTimeoutSeconds must be positive

--- a/values.yaml
+++ b/values.yaml
@@ -70,6 +70,7 @@ rollout:
       maxUnavailable: 0
       maxSurge: 1
   endpointDrainDelaySeconds: 15
+  connectionDrainTimeoutSeconds: 3600
   terminationGracePeriodSeconds: 3700
   minReadySeconds: 15
   progressDeadlineSeconds: 4200

--- a/values.yaml
+++ b/values.yaml
@@ -60,6 +60,20 @@ secrets:
 # This will set the replicaset count
 replicaCount: 1
 
+# Opt-in rollout controls for request-serving control-layer pods. Enabling this
+# keeps replacement capacity available while existing requests drain.
+rollout:
+  enabled: false
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  endpointDrainDelaySeconds: 15
+  terminationGracePeriodSeconds: 3700
+  minReadySeconds: 15
+  progressDeadlineSeconds: 4200
+
 # This sets the container image
 image:
   repository: ghcr.io/doublewordai/control-layer

--- a/values.yaml
+++ b/values.yaml
@@ -70,6 +70,7 @@ rollout:
       maxUnavailable: 0
       maxSurge: 1
   endpointDrainDelaySeconds: 15
+  # This mirrors the control-layer application's fixed maximum request wait.
   connectionDrainTimeoutSeconds: 3600
   terminationGracePeriodSeconds: 3700
   minReadySeconds: 15


### PR DESCRIPTION
## Summary

- add opt-in rolling-update and termination timing controls for request-serving control-layer pods
- delay shutdown during endpoint propagation before using the existing application SIGTERM drain
- pin the chart contract to the application's fixed one-hour request drain and reject unsafe timing or availability settings

## Why

Long-running requests can exceed Kubernetes' default 30-second termination grace. These controls keep replacement capacity available while existing handlers drain for up to one hour. Fusillade worker deployments are deliberately unchanged.

## Verification

- `just lint`
- `just test` (113 tests passed)